### PR TITLE
Calcite React demo app updates

### DIFF
--- a/2024/calcite-react/demo/.gitignore
+++ b/2024/calcite-react/demo/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+/public/assets

--- a/2024/calcite-react/demo/README.md
+++ b/2024/calcite-react/demo/README.md
@@ -13,9 +13,12 @@ Description: TODO
 ## Commands to create vite react app
 
 1. npm create vite@latest
+
+   a. Use Vite's CLI to create a TypeScript React app
+
 2. npm i @arcgis/map-components-react @esri/calcite-components-react
 
-   2a. Note: @arcgis/core @esri/calcite-components will be installed as peer
+   Note: @arcgis/core @esri/calcite-components will be installed as peer
    dependencies
 
 ## Steps to run web app locally, in terminal, run:

--- a/2024/calcite-react/demo/README.md
+++ b/2024/calcite-react/demo/README.md
@@ -10,6 +10,14 @@ Description: TODO
 - [TypeScript](https://www.typescriptlang.org/)
 - [Vite](https://vitejs.dev/)
 
+## Commands to create vite react app
+
+1. npm create vite@latest
+2. npm i @arcgis/map-components-react @esri/calcite-components-react
+
+   2a. Note: @arcgis/core @esri/calcite-components will be installed as peer
+   dependencies
+
 ## Steps to run web app locally, in terminal, run:
 
 1. `git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations.git`
@@ -17,6 +25,6 @@ Description: TODO
 3. `npm install`
 4. `npm start`
 
-Note: yarn and git is required to run the above commands.
+Note: npm and git is required to run the above commands.
 
 Demo app will be hosted at `http://localhost:5173`.

--- a/2024/calcite-react/demo/package-lock.json
+++ b/2024/calcite-react/demo/package-lock.json
@@ -8,8 +8,8 @@
       "name": "demo",
       "version": "0.0.0",
       "dependencies": {
-        "@arcgis/map-components-react": "^4.28.0-beta.40",
-        "@esri/calcite-components-react": "^2.5.1",
+        "@arcgis/map-components-react": "^4.29.8",
+        "@esri/calcite-components-react": "^2.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -36,44 +36,44 @@
       }
     },
     "node_modules/@arcgis/core": {
-      "version": "4.28.10",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.28.10.tgz",
-      "integrity": "sha512-FKvicMVDwFuKX8JKLqAfukzQU2F3AG7s3tDigTcIC4ApGRbj7Nc/F9dRfPZo+aY1Vl7Sa1FjYlo6tfV93LJ2Eg==",
+      "version": "4.29.7",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.7.tgz",
+      "integrity": "sha512-3GV5Xv3e/WKEcmvHuD2Tl9jB8aowWXH1Hwz4Lg6ZokWTlkUupRXzSiR898LkRDTL8CWise3xVCknhCyFPUZu5w==",
       "peer": true,
       "dependencies": {
         "@esri/arcgis-html-sanitizer": "~3.0.1",
         "@esri/calcite-colors": "~6.1.0",
-        "@esri/calcite-components": "^1.9.2",
+        "@esri/calcite-components": "^2.4.0",
         "@popperjs/core": "~2.11.8",
-        "@zip.js/zip.js": "~2.7.29",
-        "focus-trap": "~7.5.3",
-        "luxon": "~3.4.3",
-        "sortablejs": "~1.15.0"
+        "@vaadin/grid": "~24.3.6",
+        "@zip.js/zip.js": "~2.7.34",
+        "luxon": "~3.4.4",
+        "sortablejs": "~1.15.2"
       }
     },
     "node_modules/@arcgis/map-components": {
-      "version": "4.28.0-beta.40",
-      "resolved": "https://registry.npmjs.org/@arcgis/map-components/-/map-components-4.28.0-beta.40.tgz",
-      "integrity": "sha512-kiUd8RWMBvq1bLUAajEGZaZ7hp6j0dPiEb+7HX7Rh6N9HpKgf72bwZVMubj4pQoH+BnjznaLZ46RPLZwg46EoQ==",
+      "version": "4.29.8",
+      "resolved": "https://registry.npmjs.org/@arcgis/map-components/-/map-components-4.29.8.tgz",
+      "integrity": "sha512-RVgfNsl0EBp5/sonFiXplFjdahl3aCs60+SK/RrZnzBXhf4CMj/tD/CRpm0qjYkLe5WW9W8pHkNujJemKgCcwQ==",
       "dependencies": {
-        "@stencil/core": "2.22.3"
+        "@stencil/core": "^4.10.0"
       },
       "peerDependencies": {
-        "@arcgis/core": "~4.28.0",
-        "@esri/calcite-components": ">=1.7.0 <2.0.0"
+        "@arcgis/core": "~4.29.6",
+        "@esri/calcite-components": ">=2.2.0 <3.0.0"
       }
     },
     "node_modules/@arcgis/map-components-react": {
-      "version": "4.28.0-beta.40",
-      "resolved": "https://registry.npmjs.org/@arcgis/map-components-react/-/map-components-react-4.28.0-beta.40.tgz",
-      "integrity": "sha512-84b4yB9al4zjExuEt50srUDBI6pGR0sx06D0gci3NhtaGDsqgsrotwg6XrV/lGtj25JOcgmgtJ9o95BicMo0sQ==",
+      "version": "4.29.8",
+      "resolved": "https://registry.npmjs.org/@arcgis/map-components-react/-/map-components-react-4.29.8.tgz",
+      "integrity": "sha512-QptjEyC/Zy3YXqnH6VjsR+HYdBKaOS2J2PTRKEwQ3rYWmre7t5I2Ll8D3cFWq23r2wMW/coRodf5y9ZyBXEAng==",
       "dependencies": {
-        "@arcgis/map-components": "4.28.0-beta.40"
+        "@arcgis/map-components": "4.29.8"
       },
       "peerDependencies": {
-        "@arcgis/core": "~4.28.0",
-        "react": "^18",
-        "react-dom": "^18"
+        "@arcgis/core": "~4.29.6",
+        "react": ">=18.0.0 <19.0.0",
+        "react-dom": ">=18.0.0 <19.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -514,9 +514,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
-      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -538,39 +538,9 @@
       "peer": true
     },
     "node_modules/@esri/calcite-components": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.11.0.tgz",
-      "integrity": "sha512-H0ZqX3fEv4i0JCBEZ5SarPpd1KeXvqlEpLTtforfifIYbFAQOshP5fC2tFSL7j5pECyhBuB7rRhBiFeFejpRDw==",
-      "peer": true,
-      "dependencies": {
-        "@floating-ui/dom": "1.5.3",
-        "@stencil/core": "2.22.3",
-        "@types/color": "3.0.5",
-        "color": "4.2.3",
-        "composed-offset-position": "0.0.4",
-        "dayjs": "1.11.10",
-        "focus-trap": "7.5.4",
-        "lodash-es": "4.17.21",
-        "sortablejs": "1.15.0",
-        "timezone-groups": "0.8.0"
-      }
-    },
-    "node_modules/@esri/calcite-components-react": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-2.5.1.tgz",
-      "integrity": "sha512-cpd47rlQfdognaczfQ8quk3POyGfwGflkY7Y6VE7bv276W+BgUCWIBDl4zyKpgYNbklZLsYj6i7o9WYa/Lkevg==",
-      "dependencies": {
-        "@esri/calcite-components": "^2.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.7",
-        "react-dom": ">=16.7"
-      }
-    },
-    "node_modules/@esri/calcite-components-react/node_modules/@esri/calcite-components": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.5.1.tgz",
-      "integrity": "sha512-gvmY+xuoB7VUI0mr65/MHC3aRTrqG5cvpEsJqLAnnhvt3QyN1+XGt69QLzMv4iSPa2KvmA7GDhSqvHG9v3ZhsQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.6.0.tgz",
+      "integrity": "sha512-GbpascF/mI3TvC5EQejzMi8zDG/wv0pzGU5HzUsrzHqIkIwRruuIe7qdg/srjaEQkXwwpJKxfd8r5QaBXjlQWw==",
       "dependencies": {
         "@floating-ui/dom": "1.6.3",
         "@stencil/core": "4.9.0",
@@ -584,21 +554,19 @@
         "timezone-groups": "0.8.0"
       }
     },
-    "node_modules/@esri/calcite-components-react/node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+    "node_modules/@esri/calcite-components-react": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@esri/calcite-components-react/-/calcite-components-react-2.6.0.tgz",
+      "integrity": "sha512-wJDFKQ6E+oE8Uj1Rrj3ic2J4qfyfRLdF6n3IGBHJL+htZkU1iyz8IYeEjf4amgoHT0/i8NocgX4kES9pbfMJfw==",
       "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
+        "@esri/calcite-components": "^2.6.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.7",
+        "react-dom": ">=16.7"
       }
     },
-    "node_modules/@esri/calcite-components-react/node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
-    },
-    "node_modules/@esri/calcite-components-react/node_modules/@stencil/core": {
+    "node_modules/@esri/calcite-components/node_modules/@stencil/core": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.0.tgz",
       "integrity": "sha512-aWSkhBmk3yPwRAkUwBbzRwmdhb8hKiQ/JMr9m5jthpBZLjtppYbzz6PN2MhSMDfRp6K93eQw5WogSEH4HHuB6w==",
@@ -610,24 +578,10 @@
         "npm": ">=7.10.0"
       }
     },
-    "node_modules/@esri/calcite-components-react/node_modules/@types/color": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
-      "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
-      "dependencies": {
-        "@types/color-convert": "*"
-      }
-    },
-    "node_modules/@esri/calcite-components-react/node_modules/sortablejs": {
+    "node_modules/@esri/calcite-components/node_modules/sortablejs": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
       "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
-    },
-    "node_modules/@esri/calcite-components/node_modules/sortablejs": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w==",
-      "peer": true
     },
     "node_modules/@floating-ui/core": {
       "version": "1.6.0",
@@ -637,26 +591,19 @@
         "@floating-ui/utils": "^0.2.1"
       }
     },
-    "node_modules/@floating-ui/core/node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
-    },
     "node_modules/@floating-ui/dom": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
-      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
-      "peer": true,
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
       "dependencies": {
-        "@floating-ui/core": "^1.4.2",
-        "@floating-ui/utils": "^0.1.3"
+        "@floating-ui/core": "^1.0.0",
+        "@floating-ui/utils": "^0.2.0"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
-      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==",
-      "peer": true
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -713,6 +660,21 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+      "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==",
+      "peer": true
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -748,6 +710,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "peer": true
+    },
+    "node_modules/@polymer/polymer": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
+      "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
+      "peer": true,
+      "dependencies": {
+        "@webcomponents/shadycss": "^1.9.1"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -759,9 +736,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
-      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.1.tgz",
+      "integrity": "sha512-iU2Sya8hNn1LhsYyf0N+L4Gf9Qc+9eBTJJJsaOGUp+7x4n2M9dxTt8UvhJl3oeftSjblSlpCfvjA/IfP3g5VjQ==",
       "cpu": [
         "arm"
       ],
@@ -772,9 +749,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
-      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.1.tgz",
+      "integrity": "sha512-wlzcWiH2Ir7rdMELxFE5vuM7D6TsOcJ2Yw0c3vaBR3VOsJFVTx9xvwnAvhgU5Ii8Gd6+I11qNHwndDscIm0HXg==",
       "cpu": [
         "arm64"
       ],
@@ -785,9 +762,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
-      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.1.tgz",
+      "integrity": "sha512-YRXa1+aZIFN5BaImK+84B3uNK8C6+ynKLPgvn29X9s0LTVCByp54TB7tdSMHDR7GTV39bz1lOmlLDuedgTwwHg==",
       "cpu": [
         "arm64"
       ],
@@ -798,9 +775,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
-      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.1.tgz",
+      "integrity": "sha512-opjWJ4MevxeA8FhlngQWPBOvVWYNPFkq6/25rGgG+KOy0r8clYwL1CFd+PGwRqqMFVQ4/Qd3sQu5t7ucP7C/Uw==",
       "cpu": [
         "x64"
       ],
@@ -811,9 +788,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
-      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.1.tgz",
+      "integrity": "sha512-uBkwaI+gBUlIe+EfbNnY5xNyXuhZbDSx2nzzW8tRMjUmpScd6lCQYKY2V9BATHtv5Ef2OBq6SChEP8h+/cxifQ==",
       "cpu": [
         "arm"
       ],
@@ -824,9 +801,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
-      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.1.tgz",
+      "integrity": "sha512-0bK9aG1kIg0Su7OcFTlexkVeNZ5IzEsnz1ept87a0TUgZ6HplSgkJAnFpEVRW7GRcikT4GlPV0pbtVedOaXHQQ==",
       "cpu": [
         "arm64"
       ],
@@ -837,9 +814,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
-      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.1.tgz",
+      "integrity": "sha512-qB6AFRXuP8bdkBI4D7UPUbE7OQf7u5OL+R94JE42Z2Qjmyj74FtDdLGeriRyBDhm4rQSvqAGCGC01b8Fu2LthQ==",
       "cpu": [
         "arm64"
       ],
@@ -850,9 +827,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
-      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.1.tgz",
+      "integrity": "sha512-sHig3LaGlpNgDj5o8uPEoGs98RII8HpNIqFtAI8/pYABO8i0nb1QzT0JDoXF/pxzqO+FkxvwkHZo9k0NJYDedg==",
       "cpu": [
         "riscv64"
       ],
@@ -863,9 +840,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
-      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.1.tgz",
+      "integrity": "sha512-nD3YcUv6jBJbBNFvSbp0IV66+ba/1teuBcu+fBBPZ33sidxitc6ErhON3JNavaH8HlswhWMC3s5rgZpM4MtPqQ==",
       "cpu": [
         "x64"
       ],
@@ -876,9 +853,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
-      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.1.tgz",
+      "integrity": "sha512-7/XVZqgBby2qp/cO0TQ8uJK+9xnSdJ9ct6gSDdEr4MfABrjTyrW6Bau7HQ73a2a5tPB7hno49A0y1jhWGDN9OQ==",
       "cpu": [
         "x64"
       ],
@@ -889,9 +866,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
-      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.1.tgz",
+      "integrity": "sha512-CYc64bnICG42UPL7TrhIwsJW4QcKkIt9gGlj21gq3VV0LL6XNb1yAdHVp1pIi9gkts9gGcT3OfUYHjGP7ETAiw==",
       "cpu": [
         "arm64"
       ],
@@ -902,9 +879,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
-      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.1.tgz",
+      "integrity": "sha512-LN+vnlZ9g0qlHGlS920GR4zFCqAwbv2lULrR29yGaWP9u7wF5L7GqWu9Ah6/kFZPXPUkpdZwd//TNR+9XC9hvA==",
       "cpu": [
         "ia32"
       ],
@@ -915,9 +892,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
-      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.1.tgz",
+      "integrity": "sha512-n+vkrSyphvmU0qkQ6QBNXCGr2mKjhP08mPRM/Xp5Ck2FV4NrHU+y6axzDeixUrCBHVUS51TZhjqrKBBsHLKb2Q==",
       "cpu": [
         "x64"
       ],
@@ -928,21 +905,21 @@
       ]
     },
     "node_modules/@stencil/core": {
-      "version": "2.22.3",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.22.3.tgz",
-      "integrity": "sha512-kmVA0M/HojwsfkeHsifvHVIYe4l5tin7J5+DLgtl8h6WWfiMClND5K3ifCXXI2ETDNKiEk21p6jql3Fx9o2rng==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.12.5.tgz",
+      "integrity": "sha512-vSyFjY7XSEx0ufa9SebOd437CvnneaTXlCpuGDhjUDxAjGBlu6ie5qHyubobVGBth//aErc6wZPHc6W75Vp3iQ==",
       "bin": {
         "stencil": "bin/stencil"
       },
       "engines": {
-        "node": ">=12.10.0",
-        "npm": ">=6.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.2.tgz",
-      "integrity": "sha512-vWgY07R/eqj1/a0vsRKLI9o9klGZfpLNOVEnrv4nrccxBgYPjcf22IWwAoaBJ+wpA7Q4fVjCUM8lP0m01dpxcg==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.4.6.tgz",
+      "integrity": "sha512-A7iK9+1qzTCIuc3IYcS8gPHCm9bZVKUJrfNnwveZYyo6OFp3jLno4WOM2yBy5uqedgYATEiWgBYHKq37KrU6IA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -957,16 +934,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.4.2",
-        "@swc/core-darwin-x64": "1.4.2",
-        "@swc/core-linux-arm-gnueabihf": "1.4.2",
-        "@swc/core-linux-arm64-gnu": "1.4.2",
-        "@swc/core-linux-arm64-musl": "1.4.2",
-        "@swc/core-linux-x64-gnu": "1.4.2",
-        "@swc/core-linux-x64-musl": "1.4.2",
-        "@swc/core-win32-arm64-msvc": "1.4.2",
-        "@swc/core-win32-ia32-msvc": "1.4.2",
-        "@swc/core-win32-x64-msvc": "1.4.2"
+        "@swc/core-darwin-arm64": "1.4.6",
+        "@swc/core-darwin-x64": "1.4.6",
+        "@swc/core-linux-arm-gnueabihf": "1.4.6",
+        "@swc/core-linux-arm64-gnu": "1.4.6",
+        "@swc/core-linux-arm64-musl": "1.4.6",
+        "@swc/core-linux-x64-gnu": "1.4.6",
+        "@swc/core-linux-x64-musl": "1.4.6",
+        "@swc/core-win32-arm64-msvc": "1.4.6",
+        "@swc/core-win32-ia32-msvc": "1.4.6",
+        "@swc/core-win32-x64-msvc": "1.4.6"
       },
       "peerDependencies": {
         "@swc/helpers": "^0.5.0"
@@ -978,9 +955,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.2.tgz",
-      "integrity": "sha512-1uSdAn1MRK5C1m/TvLZ2RDvr0zLvochgrZ2xL+lRzugLlCTlSA+Q4TWtrZaOz+vnnFVliCpw7c7qu0JouhgQIw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.4.6.tgz",
+      "integrity": "sha512-bpggpx/BfLFyy48aUKq1PsNUxb7J6CINlpAUk0V4yXfmGnpZH80Gp1pM3GkFDQyCfq7L7IpjPrIjWQwCrL4hYw==",
       "cpu": [
         "arm64"
       ],
@@ -994,9 +971,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.2.tgz",
-      "integrity": "sha512-TYD28+dCQKeuxxcy7gLJUCFLqrwDZnHtC2z7cdeGfZpbI2mbfppfTf2wUPzqZk3gEC96zHd4Yr37V3Tvzar+lQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.4.6.tgz",
+      "integrity": "sha512-vJn+/ZuBTg+vtNkcmgZdH6FQpa0hFVdnB9bAeqYwKkyqP15zaPe6jfC+qL2y/cIeC7ASvHXEKrnCZgBLxfVQ9w==",
       "cpu": [
         "x64"
       ],
@@ -1010,9 +987,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.2.tgz",
-      "integrity": "sha512-Eyqipf7ZPGj0vplKHo8JUOoU1un2sg5PjJMpEesX0k+6HKE2T8pdyeyXODN0YTFqzndSa/J43EEPXm+rHAsLFQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.4.6.tgz",
+      "integrity": "sha512-hEmYcB/9XBAl02MtuVHszhNjQpjBzhk/NFulnU33tBMbNZpy2TN5yTsitezMq090QXdDz8sKIALApDyg07ZR8g==",
       "cpu": [
         "arm"
       ],
@@ -1026,9 +1003,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.2.tgz",
-      "integrity": "sha512-wZn02DH8VYPv3FC0ub4my52Rttsus/rFw+UUfzdb3tHMHXB66LqN+rR0ssIOZrH6K+VLN6qpTw9VizjyoH0BxA==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.4.6.tgz",
+      "integrity": "sha512-/UCYIVoGpm2YVvGHZM2QOA3dexa28BjcpLAIYnoCbgH5f7ulDhE8FAIO/9pasj+kixDBsdqewHfsNXFYlgGJjQ==",
       "cpu": [
         "arm64"
       ],
@@ -1042,9 +1019,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.2.tgz",
-      "integrity": "sha512-3G0D5z9hUj9bXNcwmA1eGiFTwe5rWkuL3DsoviTj73TKLpk7u64ND0XjEfO0huVv4vVu9H1jodrKb7nvln/dlw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.4.6.tgz",
+      "integrity": "sha512-LGQsKJ8MA9zZ8xHCkbGkcPSmpkZL2O7drvwsGKynyCttHhpwVjj9lguhD4DWU3+FWIsjvho5Vu0Ggei8OYi/Lw==",
       "cpu": [
         "arm64"
       ],
@@ -1058,9 +1035,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.2.tgz",
-      "integrity": "sha512-LFxn9U8cjmYHw3jrdPNqPAkBGglKE3tCZ8rA7hYyp0BFxuo7L2ZcEnPm4RFpmSCCsExFH+LEJWuMGgWERoktvg==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.4.6.tgz",
+      "integrity": "sha512-10JL2nLIreMQDKvq2TECnQe5fCuoqBHu1yW8aChqgHUyg9d7gfZX/kppUsuimqcgRBnS0AjTDAA+JF6UsG/2Yg==",
       "cpu": [
         "x64"
       ],
@@ -1074,9 +1051,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.2.tgz",
-      "integrity": "sha512-dp0fAmreeVVYTUcb4u9njTPrYzKnbIH0EhH2qvC9GOYNNREUu2GezSIDgonjOXkHiTCvopG4xU7y56XtXj4VrQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.4.6.tgz",
+      "integrity": "sha512-EGyjFVzVY6Do89x8sfah7I3cuP4MwtwzmA6OlfD/KASqfCFf5eIaEBMbajgR41bVfMV7lK72lwAIea5xEyq1AQ==",
       "cpu": [
         "x64"
       ],
@@ -1090,9 +1067,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.2.tgz",
-      "integrity": "sha512-HlVIiLMQkzthAdqMslQhDkoXJ5+AOLUSTV6fm6shFKZKqc/9cJvr4S8UveNERL9zUficA36yM3bbfo36McwnvQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.4.6.tgz",
+      "integrity": "sha512-gfW9AuXvwSyK07Vb8Y8E9m2oJZk21WqcD+X4BZhkbKB0TCZK0zk1j/HpS2UFlr1JB2zPKPpSWLU3ll0GEHRG2A==",
       "cpu": [
         "arm64"
       ],
@@ -1106,9 +1083,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.2.tgz",
-      "integrity": "sha512-WCF8faPGjCl4oIgugkp+kL9nl3nUATlzKXCEGFowMEmVVCFM0GsqlmGdPp1pjZoWc9tpYanoXQDnp5IvlDSLhA==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.4.6.tgz",
+      "integrity": "sha512-ZuQm81FhhvNVYtVb9GfZ+Du6e7fZlkisWvuCeBeRiyseNt1tcrQ8J3V67jD2nxje8CVXrwG3oUIbPcybv2rxfQ==",
       "cpu": [
         "ia32"
       ],
@@ -1122,9 +1099,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.2.tgz",
-      "integrity": "sha512-oV71rwiSpA5xre2C5570BhCsg1HF97SNLsZ/12xv7zayGzqr3yvFALFJN8tHKpqUdCB4FGPjoP3JFdV3i+1wUw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.4.6.tgz",
+      "integrity": "sha512-UagPb7w5V0uzWSjrXwOavGa7s9iv3wrVdEgWy+/inm0OwY4lj3zpK9qDnMWAwYLuFwkI3UG4Q3dH8wD+CUUcjw==",
       "cpu": [
         "x64"
       ],
@@ -1150,10 +1127,9 @@
       "dev": true
     },
     "node_modules/@types/color": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.5.tgz",
-      "integrity": "sha512-T9yHCNtd8ap9L/r8KEESu5RDMLkoWXHo7dTureNoI1dbp25NsCN054vOu09iniIjR21MXUL+LU9bkIWrbyg8gg==",
-      "peer": true,
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
+      "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
       "dependencies": {
         "@types/color-convert": "*"
       }
@@ -1190,9 +1166,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.57",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.57.tgz",
-      "integrity": "sha512-ZvQsktJgSYrQiMirAN60y4O/LRevIV8hUzSOSNB6gfR3/o3wCBFQx3sPwIYtuDMeiVgsSS3UzCV26tEzgnfvQw==",
+      "version": "18.2.64",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
+      "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -1201,9 +1177,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.2.19",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.19.tgz",
-      "integrity": "sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==",
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.21.tgz",
+      "integrity": "sha512-gnvBA/21SA4xxqNXEwNiVcP0xSGHh/gi1VhWv9Bl46a0ItbTT5nFY+G9VSQpaG/8N/qdJpJ+vftQ4zflTtnjLw==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -1216,10 +1192,16 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
-      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -1417,6 +1399,186 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@vaadin/a11y-base": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.8.tgz",
+      "integrity": "sha512-BCbPcsFmXWf47JFpkeoLBK+eRSR8CwVLoWdre/z/yNTpW0sKChBi8fUbW5HU2mN021rDobAShyu+ZZ6Hwd0cLw==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.8",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/checkbox": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.8.tgz",
+      "integrity": "sha512-13ViRjxf7pho6DbC2cReDwG4XuDlhr5WY6N8diB5lj3b/aXr/hzVltxEFd98HVGkX5st4Qo/ERkyq6FUUrmRKA==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.8",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/field-base": "~24.3.8",
+        "@vaadin/vaadin-lumo-styles": "~24.3.8",
+        "@vaadin/vaadin-material-styles": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/component-base": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.8.tgz",
+      "integrity": "sha512-uHXZ/6CwdWzsu0V+SqZC6oKvHVhHaY7hAgjjOzgp+x4BQ/kkN+1Uj/09KYqmM51EXODpYYY/EN16Ut9kd/BGtQ==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/field-base": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.8.tgz",
+      "integrity": "sha512-bRK0C4v2c+LTmFP2d9gh5VkKnYaAP3FRy2ze4Dw58Hi2twagw2eanUX1AeVpU6pamA7zeDcbJwdgGO1/VdiRLA==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.8",
+        "@vaadin/component-base": "~24.3.8",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/grid": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.8.tgz",
+      "integrity": "sha512-rhux0J47TH98dgB9r1hIhVtq1418g17yByND1Ua0ss2KnIdAmRjlM98B2ALlfeV4Jse4iYpxe7aglO+48pPY3A==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.8",
+        "@vaadin/checkbox": "~24.3.8",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/lit-renderer": "~24.3.8",
+        "@vaadin/text-field": "~24.3.8",
+        "@vaadin/vaadin-lumo-styles": "~24.3.8",
+        "@vaadin/vaadin-material-styles": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8"
+      }
+    },
+    "node_modules/@vaadin/icon": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.8.tgz",
+      "integrity": "sha512-KDz0qxS/nNiT8UpR7WRXEy21lPhn4fNyk7BpLuwLK0oZG1ULHqmuoYVYpOVhKlEcxpOlaNxK6bfcJ+pupDvWVA==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/vaadin-lumo-styles": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/input-container": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.8.tgz",
+      "integrity": "sha512-tidh+7ITtPvnGrpdJj5eUmlRqRwXFSW8JfQs2gT9FRTb+FMGAUBHm4v8qAthL0D1ctnanK8QNSAZJlZWNXU5+w==",
+      "peer": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/vaadin-lumo-styles": "~24.3.8",
+        "@vaadin/vaadin-material-styles": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/lit-renderer": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.8.tgz",
+      "integrity": "sha512-qERkHUidtciNNOpHTIaKvakXPd3KLpWH0iyn/JKo9VRxn7Cm2fqjSgtlgENykRyVoNzKCRj/NH9BrO8xmfCqtw==",
+      "peer": true,
+      "dependencies": {
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/text-field": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.8.tgz",
+      "integrity": "sha512-8/4UWFziL5frN9jsposZDq0pbHK/RwYmGdOTrUyBzE/oS/JSsLNAbI9/+aEVDTKbPvQ1rc/5r7fIA5LXV+acJQ==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/a11y-base": "~24.3.8",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/field-base": "~24.3.8",
+        "@vaadin/input-container": "~24.3.8",
+        "@vaadin/vaadin-lumo-styles": "~24.3.8",
+        "@vaadin/vaadin-material-styles": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.6.tgz",
+      "integrity": "sha512-N6a5nLT/ytEUlpPo+nvdCKIGoyNjPsj3rzPGvGYK8x9Ceg76OTe1xI/GtN71mRW9e2HUScR0kCNOkl1Z63YDjw==",
+      "peer": true
+    },
+    "node_modules/@vaadin/vaadin-lumo-styles": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.8.tgz",
+      "integrity": "sha512-AuaGJ/Pjxy4F0s+t66O3YsvaqwPHeYRP+ajp7UD7EIQ9m6zn1zON/aAXfI6y4krKdieAnWdaIhhimMWzQlKsUg==",
+      "peer": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/icon": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8"
+      }
+    },
+    "node_modules/@vaadin/vaadin-material-styles": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.8.tgz",
+      "integrity": "sha512-Ise2B2Xe/wCmIYrgTfPUvufDETMGbNOrgtxqoehqDm9hgQKQ/JfULPM+G1JFDNQnCSCANmtQ5lmKzcwSHEzD0g==",
+      "peer": true,
+      "dependencies": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/component-base": "~24.3.8",
+        "@vaadin/vaadin-themable-mixin": "~24.3.8"
+      }
+    },
+    "node_modules/@vaadin/vaadin-themable-mixin": {
+      "version": "24.3.8",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.8.tgz",
+      "integrity": "sha512-q1jh0SqT7uNMiRnpJi8HrTEggx0DhoMZfuA8TcVCuiy3yh0xPD2GC+Uc6DViq4X2R/q+8YJLNnLvMntSPJPcmQ==",
+      "peer": true,
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "node_modules/@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
+      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.6.0.tgz",
@@ -1429,10 +1591,16 @@
         "vite": "^4 || ^5"
       }
     },
+    "node_modules/@webcomponents/shadycss": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+      "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==",
+      "peer": true
+    },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.34",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.34.tgz",
-      "integrity": "sha512-SWAK+hLYKRHswhakNUirPYrdsflSFOxykUckfbWDcPvP8tjLuV5EWyd3GHV0hVaJLDps40jJnv8yQVDbWnQDfg==",
+      "version": "2.7.40",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.40.tgz",
+      "integrity": "sha512-kSYwO0Wth6G66QM4CejZqG0nRhBsVVTaR18M/Ta8EcqcvaV0dYrnDDyKAstfy0V5+ejK4b9w5xc1W0ECATJTvA==",
       "peer": true,
       "engines": {
         "bun": ">=0.7.0",
@@ -1751,16 +1919,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
-      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.56.0",
-        "@humanwhocodes/config-array": "^0.11.13",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -2339,6 +2507,37 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lit": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
+      "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+      "peer": true,
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
+      "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+      "peer": true,
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.1.2"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
+      "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+      "peer": true,
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2710,9 +2909,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
-      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.1.tgz",
+      "integrity": "sha512-ggqQKvx/PsB0FaWXhIvVkSWh7a/PCLQAsMjBc+nA2M8Rv2/HG0X6zvixAB7KyZBRtifBUhy5k8voQX/mRnABPg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -2725,19 +2924,19 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.12.0",
-        "@rollup/rollup-android-arm64": "4.12.0",
-        "@rollup/rollup-darwin-arm64": "4.12.0",
-        "@rollup/rollup-darwin-x64": "4.12.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
-        "@rollup/rollup-linux-arm64-musl": "4.12.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-musl": "4.12.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
-        "@rollup/rollup-win32-x64-msvc": "4.12.0",
+        "@rollup/rollup-android-arm-eabi": "4.12.1",
+        "@rollup/rollup-android-arm64": "4.12.1",
+        "@rollup/rollup-darwin-arm64": "4.12.1",
+        "@rollup/rollup-darwin-x64": "4.12.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.12.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.12.1",
+        "@rollup/rollup-linux-arm64-musl": "4.12.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-gnu": "4.12.1",
+        "@rollup/rollup-linux-x64-musl": "4.12.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.12.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.12.1",
+        "@rollup/rollup-win32-x64-msvc": "4.12.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -2944,9 +3143,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2966,9 +3165,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
-      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
+      "integrity": "sha512-BdN1xh0Of/oQafhU+FvopafUp6WaYenLU/NFoL5WyJL++GxkNfieKzBhM24H3HVsPQrlAqB7iJYTHabzaRed5Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.19.3",

--- a/2024/calcite-react/demo/package.json
+++ b/2024/calcite-react/demo/package.json
@@ -4,14 +4,15 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "vite",
-    "build": "tsc && vite build",
+    "start": "npm run copy && vite",
+    "build": "npm run copy && vite build",
+    "copy": "cp -r node_modules/@esri/calcite-components/dist/calcite/assets/* ./public/assets/",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components-react": "^4.28.0-beta.40",
-    "@esri/calcite-components-react": "^2.5.1",
+    "@arcgis/map-components-react": "^4.29.8",
+    "@esri/calcite-components-react": "^2.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/2024/calcite-react/demo/package.json
+++ b/2024/calcite-react/demo/package.json
@@ -4,9 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "npm run copy && vite",
-    "build": "npm run copy && vite build",
-    "copy": "cp -r node_modules/@esri/calcite-components/dist/calcite/assets/* ./public/assets/",
+    "start": "vite",
+    "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },

--- a/2024/calcite-react/demo/public/assets/.gitignore
+++ b/2024/calcite-react/demo/public/assets/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/2024/calcite-react/demo/public/assets/.gitignore
+++ b/2024/calcite-react/demo/public/assets/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/2024/calcite-react/demo/src/App.tsx
+++ b/2024/calcite-react/demo/src/App.tsx
@@ -31,9 +31,9 @@ function App({ webmap, title, panelHeading }: AppProps) {
       <Panel map={map} panelHeading={panelHeading} />
       {/* Default content slot */}
       <ArcgisMap
-        itemId={webmap}
-        // Step 10: Use onArcgisViewReadyChange to store map in state to pass into panel
+        // Step 10: setMap on Arcgis ViewReadyChange
         onArcgisViewReadyChange={(e) => setMap(e.target)}
+        itemId={webmap}
       />
     </CalciteShell>
   );

--- a/2024/calcite-react/demo/src/App.tsx
+++ b/2024/calcite-react/demo/src/App.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
 
 // Step 6: Import Calcite Shell
-import '@esri/calcite-components/dist/components/calcite-shell';
-
 // Please note: At React 19, we are expecting React to fully support web components which will eliminate the need for web component wrappers, but as of now we will use these.
 import { CalciteShell } from '@esri/calcite-components-react';
 

--- a/2024/calcite-react/demo/src/App.tsx
+++ b/2024/calcite-react/demo/src/App.tsx
@@ -21,7 +21,7 @@ interface AppProps {
 
 function App({ webmap, title, panelHeading }: AppProps) {
   // Step 8: Set up state to store view to pass into other components (Panel)
-  const [view, setView] = useState<__esri.MapView | null>(null);
+  const [map, setMap] = useState<HTMLArcgisMapElement | null>(null);
 
   // Step 9: Render app layout: Calcite shell, along with header, panel, and map
   // Calcite Components Documentation: https://developers.arcgis.com/calcite-design-system/components/shell
@@ -30,16 +30,12 @@ function App({ webmap, title, panelHeading }: AppProps) {
       {/* Header slot */}
       <Header title={title} />
       {/* Panel Start slot */}
-      <Panel view={view} panelHeading={panelHeading} />
+      <Panel map={map} panelHeading={panelHeading} />
       {/* Default content slot */}
       <ArcgisMap
         itemId={webmap}
-        // Step 10: Listen for on view ready
-        onViewReady={(e) => {
-          const { view } = e.detail;
-          // Store view in state, and pass that into panel
-          setView(view);
-        }}
+        // Step 10: Use onArcgisViewReadyChange to store map in state to pass into panel
+        onArcgisViewReadyChange={(e) => setMap(e.target)}
       />
     </CalciteShell>
   );

--- a/2024/calcite-react/demo/src/App.tsx
+++ b/2024/calcite-react/demo/src/App.tsx
@@ -6,7 +6,7 @@ import '@esri/calcite-components/dist/components/calcite-shell';
 // Please note: At React 19, we are expecting React to fully support web components which will eliminate the need for web component wrappers, but as of now we will use these.
 import { CalciteShell } from '@esri/calcite-components-react';
 
-// Step 7: Import ArcGIS Maps SDK for JavaScript
+// Step 7: Import ArcgisMap from map-components
 import '@arcgis/map-components/dist/components/arcgis-map';
 import { ArcgisMap } from '@arcgis/map-components-react';
 

--- a/2024/calcite-react/demo/src/App.tsx
+++ b/2024/calcite-react/demo/src/App.tsx
@@ -20,6 +20,7 @@ interface AppProps {
 function App({ webmap, title, panelHeading }: AppProps) {
   // Step 8: Set up state to store view to pass into other components (Panel)
   const [map, setMap] = useState<HTMLArcgisMapElement | null>(null);
+  const mapId = 'arcgis-map';
 
   // Step 9: Render app layout: Calcite shell, along with header, panel, and map
   // Calcite Components Documentation: https://developers.arcgis.com/calcite-design-system/components/shell
@@ -28,9 +29,10 @@ function App({ webmap, title, panelHeading }: AppProps) {
       {/* Header slot */}
       <Header title={title} />
       {/* Panel Start slot */}
-      <Panel map={map} panelHeading={panelHeading} />
+      <Panel map={map} panelHeading={panelHeading} mapId={mapId} />
       {/* Default content slot */}
       <ArcgisMap
+        id={mapId}
         // Step 10: setMap on Arcgis ViewReadyChange
         onArcgisViewReadyChange={(e) => setMap(e.target)}
         itemId={webmap}

--- a/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
+++ b/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
@@ -11,7 +11,7 @@ import {
   CalcitePanel,
 } from '@esri/calcite-components-react';
 
-// Step 12: Import Features components
+// Step 12: Import Features component
 import '@arcgis/map-components/dist/components/arcgis-features';
 import { ArcgisFeatures } from '@arcgis/map-components-react';
 
@@ -25,14 +25,13 @@ interface PanelProps {
 
 export const Panel = ({ view, panelHeading }: PanelProps) => {
   // Step 14: Set up state to store features component - to eventually set up click handle
-  const [featuresWidget, setFeaturesWidget] = useState<__esri.Features | null>(
-    null,
-  );
+  const [featuresComponent, setFeaturesComponent] =
+    useState<__esri.Features | null>(null);
 
   // Step 15: useEffect - when features component and view is available, set up click handle
   // On click, open the clicked feature if any
   useEffect(() => {
-    if (!featuresWidget || !view) return;
+    if (!featuresComponent || !view) return;
 
     // Disable popup for features widget as feature information will be rendered in side panel
     view.popupEnabled = false;
@@ -41,14 +40,14 @@ export const Panel = ({ view, panelHeading }: PanelProps) => {
       () => view,
       'click',
       (event) => {
-        featuresWidget.open({
+        featuresComponent.open({
           location: event.mapPoint,
           fetchFeatures: true,
         });
       },
     );
     return () => clickHandle.remove();
-  }, [view, featuresWidget]);
+  }, [view, featuresComponent]);
 
   // Step 16: Render shell panel, containing features component
   return (
@@ -62,7 +61,7 @@ export const Panel = ({ view, panelHeading }: PanelProps) => {
           <ArcgisFeatures
             view={view}
             // Step 18: Listen for on widget ready to store features component in react component's state
-            onWidgetReady={(e) => setFeaturesWidget(e.detail.widget)}
+            onWidgetReady={(e) => setFeaturesComponent(e.detail.widget)}
           />
         ) : null}
       </CalcitePanel>

--- a/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
+++ b/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
@@ -24,7 +24,7 @@ export const Panel = ({ map, panelHeading }: PanelProps) => {
   // Step 14: useEffect - when features component and view is available, set up click handle
   // On click, open the clicked feature if any
   useEffect(() => {
-    if (!featuresComponent || !map) return;
+    if (!featuresComponent || !map?.view) return;
 
     // Step 15
     //   15a. Set view on features component
@@ -47,9 +47,8 @@ export const Panel = ({ map, panelHeading }: PanelProps) => {
     <CalciteShellPanel slot="panel-start">
       {/* Block to render panel heading  */}
       <CalciteBlock heading={panelHeading} />
-
       {/* Panel to render features widget container node */}
-      <CalcitePanel>
+      <CalcitePanel loading={!map?.view ? true : false}>
         {/* Step 17: Render Features component to display feature information in
         side panel on click */}
         <ArcgisFeatures

--- a/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
+++ b/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
@@ -25,7 +25,7 @@ export const Panel = ({ map, panelHeading, mapId }: PanelProps) => {
   // Step 14: useEffect - when features component and view is available, set up click handle
   // On click, open the clicked feature if any
   useEffect(() => {
-    if (!featuresComponent || !map?.view) return;
+    if (!featuresComponent || map == null) return;
 
     // Step 15: disable popup for features widget as feature information will be rendered in side panel
     map.view.popupEnabled = false;
@@ -46,7 +46,7 @@ export const Panel = ({ map, panelHeading, mapId }: PanelProps) => {
       {/* Block to render panel heading  */}
       <CalciteBlock heading={panelHeading} />
       {/* Panel to render features widget container node */}
-      <CalcitePanel loading={!map?.view ? true : false}>
+      <CalcitePanel loading={map == null}>
         {/* Step 17: Render Features component to display feature information in
         side panel on click */}
         <ArcgisFeatures

--- a/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
+++ b/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
@@ -15,55 +15,51 @@ import {
 import '@arcgis/map-components/dist/components/arcgis-features';
 import { ArcgisFeatures } from '@arcgis/map-components-react';
 
-// Step 13: Import reactiveUtils.on to listen for view click
-import { on } from '@arcgis/core/core/reactiveUtils';
-
 interface PanelProps {
-  view: __esri.MapView | null;
+  map: HTMLArcgisMapElement | null;
   panelHeading: string;
 }
 
-export const Panel = ({ view, panelHeading }: PanelProps) => {
-  // Step 14: Set up state to store features component - to eventually set up click handle
+export const Panel = ({ map, panelHeading }: PanelProps) => {
+  // Step 13: Set up state to store features component - to eventually set up click handle
   const [featuresComponent, setFeaturesComponent] =
-    useState<__esri.Features | null>(null);
+    useState<HTMLArcgisFeaturesElement | null>(null);
 
-  // Step 15: useEffect - when features component and view is available, set up click handle
+  // Step 14: useEffect - when features component and view is available, set up click handle
   // On click, open the clicked feature if any
   useEffect(() => {
-    if (!featuresComponent || !view) return;
+    if (!featuresComponent || !map) return;
 
-    // Disable popup for features widget as feature information will be rendered in side panel
-    view.popupEnabled = false;
+    // Step 15
+    //   15a. Set view on features component
+    //   15b. disable popup for features widget as feature information will be rendered in side panel
+    featuresComponent.view = map.view;
+    map.view.popupEnabled = false;
 
-    const clickHandle = on(
-      () => view,
-      'click',
-      (event) => {
-        featuresComponent.open({
-          location: event.mapPoint,
-          fetchFeatures: true,
-        });
-      },
-    );
-    return () => clickHandle.remove();
-  }, [view, featuresComponent]);
+    const handle = map.view.on('click', (event) => {
+      featuresComponent.open({
+        location: event.mapPoint,
+        fetchFeatures: true,
+      });
+    });
+
+    return () => handle.remove();
+  }, [featuresComponent, map]);
 
   // Step 16: Render shell panel, containing features component
   return (
     <CalciteShellPanel slot="panel-start">
       {/* Block to render panel heading  */}
       <CalciteBlock heading={panelHeading} />
+
       {/* Panel to render features widget container node */}
       <CalcitePanel>
-        {view ? (
-          // Step 17: Render Features component to display feature information in side panel on click
-          <ArcgisFeatures
-            view={view}
-            // Step 18: Listen for on widget ready to store features component in react component's state
-            onWidgetReady={(e) => setFeaturesComponent(e.detail.widget)}
-          />
-        ) : null}
+        {/* Step 17: Render Features component to display feature information in
+        side panel on click */}
+        <ArcgisFeatures
+          // Step 18: Use onArcgisFeaturesReady to store ArcgisFeatures in react component's state
+          onArcgisFeaturesReady={(e) => setFeaturesComponent(e.target)}
+        />
       </CalcitePanel>
     </CalciteShellPanel>
   );

--- a/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
+++ b/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useState } from 'react';
 
-// Step 11: Panel, Shell Panel, and Block and the associated react wrappers
-import '@esri/calcite-components/dist/components/calcite-block';
-import '@esri/calcite-components/dist/components/calcite-shell-panel';
-import '@esri/calcite-components/dist/components/calcite-panel';
-
+// Step 11: Import CalciteBlock, CalciteShellPanel, and CalcitePanel
 import {
   CalciteBlock,
   CalciteShellPanel,

--- a/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
+++ b/2024/calcite-react/demo/src/Components/Panel/Panel.tsx
@@ -14,9 +14,10 @@ import { ArcgisFeatures } from '@arcgis/map-components-react';
 interface PanelProps {
   map: HTMLArcgisMapElement | null;
   panelHeading: string;
+  mapId: string;
 }
 
-export const Panel = ({ map, panelHeading }: PanelProps) => {
+export const Panel = ({ map, panelHeading, mapId }: PanelProps) => {
   // Step 13: Set up state to store features component - to eventually set up click handle
   const [featuresComponent, setFeaturesComponent] =
     useState<HTMLArcgisFeaturesElement | null>(null);
@@ -26,10 +27,7 @@ export const Panel = ({ map, panelHeading }: PanelProps) => {
   useEffect(() => {
     if (!featuresComponent || !map?.view) return;
 
-    // Step 15
-    //   15a. Set view on features component
-    //   15b. disable popup for features widget as feature information will be rendered in side panel
-    featuresComponent.view = map.view;
+    // Step 15: disable popup for features widget as feature information will be rendered in side panel
     map.view.popupEnabled = false;
 
     const handle = map.view.on('click', (event) => {
@@ -52,7 +50,9 @@ export const Panel = ({ map, panelHeading }: PanelProps) => {
         {/* Step 17: Render Features component to display feature information in
         side panel on click */}
         <ArcgisFeatures
-          // Step 18: Use onArcgisFeaturesReady to store ArcgisFeatures in react component's state
+          // Step 18: Because ArcgisFeatures is displayed outside the map, we need to pass a reference to the map
+          referenceElement={mapId}
+          // Step 19: Use onArcgisFeaturesReady to store ArcgisFeatures in react component's state
           onArcgisFeaturesReady={(e) => setFeaturesComponent(e.target)}
         />
       </CalcitePanel>

--- a/2024/calcite-react/demo/src/main.tsx
+++ b/2024/calcite-react/demo/src/main.tsx
@@ -16,16 +16,11 @@ import {
   panelHeading,
 } from './config/application.json';
 
-// Step 4: Calcite Components
-// 4a. Use setAssetPath to the path where assets were copied (occurs in package.json)
-import { setAssetPath } from '@esri/calcite-components/dist/components';
-const { href } = new URL(`${window.location.href}assets`);
-setAssetPath(href);
-
-// 4b. Use defineCustomElements to load calcite components into the app
+// Step 4: Calcite Components: Use defineCustomElements to load calcite components into the app
 import { defineCustomElements } from '@esri/calcite-components/dist/loader';
+// CDN hosted assets
 defineCustomElements(window, {
-  resourcesUrl: href,
+  resourcesUrl: 'https://js.arcgis.com/calcite-components/2.6.0/assets',
 });
 
 // Step 5: Set portal URL to work with content from within ArcGIS Online or ArcGIS Enterprise Portal

--- a/2024/calcite-react/demo/src/main.tsx
+++ b/2024/calcite-react/demo/src/main.tsx
@@ -16,12 +16,11 @@ import {
   panelHeading,
 } from './config/application.json';
 
-// Step 4: Calcite Components Assets (Recommended to use CDN based on documentation)
-// Please note: You can also manage assets locally by copying assets directly from Calcite Components in your project.
-import { setAssetPath } from '@esri/calcite-components/dist/components/index';
-setAssetPath(
-  'https://cdn.jsdelivr.net/npm/@esri/calcite-components/dist/calcite/assets',
-);
+// Step 4: Calcite Components Assets
+// Use setAssetPath to the path where assets were copied (occurs in package.json)
+import { setAssetPath } from '@esri/calcite-components/dist/components';
+const { href } = new URL(`${window.location.href}assets`);
+setAssetPath(href);
 
 // Step 5: Set portal URL to work with content from within ArcGIS Online or ArcGIS Enterprise Portal
 esriConfig.portalUrl = portalUrl;

--- a/2024/calcite-react/demo/src/main.tsx
+++ b/2024/calcite-react/demo/src/main.tsx
@@ -16,11 +16,17 @@ import {
   panelHeading,
 } from './config/application.json';
 
-// Step 4: Calcite Components Assets
-// Use setAssetPath to the path where assets were copied (occurs in package.json)
+// Step 4: Calcite Components
+// 4a. Use setAssetPath to the path where assets were copied (occurs in package.json)
 import { setAssetPath } from '@esri/calcite-components/dist/components';
 const { href } = new URL(`${window.location.href}assets`);
 setAssetPath(href);
+
+// 4b. Use defineCustomElements to load calcite components into the app
+import { defineCustomElements } from '@esri/calcite-components/dist/loader';
+defineCustomElements(window, {
+  resourcesUrl: href,
+});
 
 // Step 5: Set portal URL to work with content from within ArcGIS Online or ArcGIS Enterprise Portal
 esriConfig.portalUrl = portalUrl;

--- a/2024/calcite-react/index.md
+++ b/2024/calcite-react/index.md
@@ -251,7 +251,7 @@
 Installation:
 
 ```sh
-npx create-react-app my-app --template typescript
+npm vite@latest
 npm install @esri/calcite-components-react
 npm install @arcgis/core
 ```
@@ -268,8 +268,8 @@ Add copy script and build scripts:
 > speaker notes:
 >
 > (Ryan) To start, create the app using the React builder of your choice. For
-> this example here, we’re using create-react-app and starting off with the
-> TypeScript template.
+> this example here, we’re using Vite's CLI to create a TypeScript React
+> application.
 >
 > Next, install calcite-components-react. We don’t need to install
 > calcite-components because it’s a dependency of this package.
@@ -284,13 +284,6 @@ Add copy script and build scripts:
 > speaker notes:
 >
 > (Ryan)
-
-## Adding Custom Widgets to the View
-
-> speaker notes:
->
-> (Ryan) Demonstrate usage of Calcite Components within React Components and
-> showcase app as it's being built
 
 ## Good practices
 

--- a/2024/calcite-react/index.md
+++ b/2024/calcite-react/index.md
@@ -248,7 +248,7 @@
 
 ## Development Environment Setup
 
-Installation:
+Reat application setup:
 
 ```sh
 npm vite@latest

--- a/2024/calcite-react/index.md
+++ b/2024/calcite-react/index.md
@@ -253,7 +253,7 @@ Installation:
 ```sh
 npm vite@latest
 npm install @esri/calcite-components-react
-npm install @arcgis/core
+npm install @arcgis/map-components-react
 ```
 
 Add copy script and build scripts:
@@ -274,10 +274,10 @@ Add copy script and build scripts:
 > Next, install calcite-components-react. We don’t need to install
 > calcite-components because it’s a dependency of this package.
 >
-> Install the ES module build of ArcGIS API for JS
+> Install the map-components-react package
 >
-> And finally, install ncp. We'll use that to copy the assets over. This allows
-> icon to show and the date picker to be properly translated.
+> Note that installing both of these packages will install
+> @esri/calcite-components and @arcgis/core as peer dependencies
 
 ## Layout + Feature
 

--- a/2024/calcite-react/index.md
+++ b/2024/calcite-react/index.md
@@ -279,7 +279,7 @@ Add copy script and build scripts:
 > Note that installing both of these packages will install
 > @esri/calcite-components and @arcgis/core as peer dependencies
 
-## Layout + Feature
+## Demo app
 
 > speaker notes:
 >


### PR DESCRIPTION
Updates include:
- Instructions in README.md
- Package versions to latest
- Include commands to copy assets to public/assets directory and set asset path to locally copied assets
- Code updates based on changes from @arcgis/map-components
- Use defineCustomElements to define calcite components in app (avoids step of having to import)
- Remove slide that isn't needed