### PR TITLE
ci(2025): deploy Slidev to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: GitHub Pages Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: actions/setup-node@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Slides > 2025 > Build Tooling
+        working-directory: 2025/build-tooling
+        run: |
+          npx slidev build --base /${{github.event.repository.name}}/2025/build-tooling/ --out ../../dist/2025/build-tooling
+
+      - name: Build Slides > 2025 > Using Components 2
+        working-directory: 2025/using-components-2
+        run: |
+          npx slidev build --base /${{github.event.repository.name}}/2025/using-components-2/ --out ../../dist/2025/using-components-2/
+
+      - name: Collect build outputs
+        run: |
+          mv -f 2024 dist/2024
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
           mv -f 2024 dist/2024
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Deploy Sldev to Github Pages.
Docs: https://sli.dev/guide/hosting

See GitHub Action logs from a test run: https://github.com/maxpatiiuk/esri-dev-summit-presentations/actions/runs/12879760564/job/35907734695?pr=18
Doesn't seem to be a way to actually deploy to pages until this PR is merged so I might need to do fixups after this PR