### PR TITLE
refactor(2025-build-tooling): update slides & update demos

### DIFF
--- a/2025/.meta/styles.css
+++ b/2025/.meta/styles.css
@@ -5,12 +5,23 @@
   font-family: Arial;
 }
 
+.slidev-layout {
+  padding-left: 4.5rem;
+  padding-right: 4.5rem;
+  padding-top: 4.5rem;
+  padding-bottom: 4.5rem;
+}
+
 .slidev-layout.cover {
   padding-left: 4.5rem;
 }
 
 .slidev-layout:is(.cover, .intro, [is="social"]) p {
   color: #ffad29;
+}
+
+.slidev-layout h1 {
+  margin-bottom: 2rem;
 }
 
 .slidev-layout h1 + p {

--- a/2025/.meta/styles.css
+++ b/2025/.meta/styles.css
@@ -32,3 +32,12 @@
   position: absolute;
   z-index: -1;;
 }
+
+.slidev-layout ul {
+  list-style: disc;
+}
+
+.slidev-layout li::marker {
+  color: #ffad29;
+  font-size: 0.75em;
+}

--- a/2025/build-tooling/demo/6-routes/src/App.tsx
+++ b/2025/build-tooling/demo/6-routes/src/App.tsx
@@ -1,13 +1,6 @@
 import { useState, useRef } from "react";
-import "@esri/calcite-components/components/calcite-alert";
 import "@esri/calcite-components/components/calcite-shell";
 import "@esri/calcite-components/components/calcite-shell-panel";
-import "@esri/calcite-components/components/calcite-list";
-import "@esri/calcite-components/components/calcite-list-item";
-import "@esri/calcite-components/components/calcite-list-item-group";
-import "@esri/calcite-components/components/calcite-navigation";
-import "@esri/calcite-components/components/calcite-navigation-logo";
-import "@esri/calcite-components/components/calcite-progress";
 import "@arcgis/map-components/components/arcgis-features";
 import "@arcgis/map-components/components/arcgis-legend";
 import "@arcgis/map-components/components/arcgis-map";

--- a/2025/build-tooling/demo/7-testing/src/App.tsx
+++ b/2025/build-tooling/demo/7-testing/src/App.tsx
@@ -5,8 +5,6 @@ import "@esri/calcite-components/components/calcite-shell-panel";
 import "@esri/calcite-components/components/calcite-list";
 import "@esri/calcite-components/components/calcite-list-item";
 import "@esri/calcite-components/components/calcite-list-item-group";
-import "@esri/calcite-components/components/calcite-navigation";
-import "@esri/calcite-components/components/calcite-navigation-logo";
 import "@esri/calcite-components/components/calcite-progress";
 import "@arcgis/map-components/components/arcgis-features";
 import "@arcgis/map-components/components/arcgis-legend";

--- a/2025/build-tooling/demo/8-plugins/src/App.tsx
+++ b/2025/build-tooling/demo/8-plugins/src/App.tsx
@@ -87,14 +87,15 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
         categoryIds: ["4d4b7105d754a06372d81259"], // Schools
         authentication: placesServiceInfo.authentication,
         endpoint: placesServiceInfo.endpoint,
-        // signal: abortController.current.signal,
       });
     } catch (error) {
-      if (error instanceof Error && error.name !== "AbortError") {
+      if (error instanceof Error) {
         setSchoolResults({ error });
       }
       return;
     }
+
+    // if (abortController.current.signal.aborted) return;
 
     // Create graphics for each school and set the result
     const graphics = response.results.map((result) => {

--- a/2025/build-tooling/demo/8-plugins/src/App.tsx
+++ b/2025/build-tooling/demo/8-plugins/src/App.tsx
@@ -5,8 +5,6 @@ import "@esri/calcite-components/components/calcite-shell-panel";
 import "@esri/calcite-components/components/calcite-list";
 import "@esri/calcite-components/components/calcite-list-item";
 import "@esri/calcite-components/components/calcite-list-item-group";
-import "@esri/calcite-components/components/calcite-navigation";
-import "@esri/calcite-components/components/calcite-navigation-logo";
 import "@esri/calcite-components/components/calcite-progress";
 import "@arcgis/map-components/components/arcgis-features";
 import "@arcgis/map-components/components/arcgis-legend";

--- a/2025/build-tooling/demo/8-plugins/vite.config.ts
+++ b/2025/build-tooling/demo/8-plugins/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
           {
             apiUrl: "/arcgis",
             delay: 400,
-            chaosRatio: 0.1,
+            chaosRatio: 0.5,
             // https://developers.arcgis.com/rest/places/near-point-get/#response
             chaosErrors: [400, 401, 403, 500],
           },

--- a/2025/build-tooling/demo/final/src/App.tsx
+++ b/2025/build-tooling/demo/final/src/App.tsx
@@ -87,14 +87,15 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
         categoryIds: ["4d4b7105d754a06372d81259"], // Schools
         authentication: placesServiceInfo.authentication,
         endpoint: placesServiceInfo.endpoint,
-        signal: abortController.current.signal,
       });
     } catch (error) {
-      if (error instanceof Error && error.name !== "AbortError") {
+      if (error instanceof Error) {
         setSchoolResults({ error });
       }
       return;
     }
+
+    if (abortController.current.signal.aborted) return;
 
     // Create graphics for each school and set the result
     const graphics = response.results.map((result) => {

--- a/2025/build-tooling/demo/final/src/App.tsx
+++ b/2025/build-tooling/demo/final/src/App.tsx
@@ -5,8 +5,6 @@ import "@esri/calcite-components/components/calcite-shell-panel";
 import "@esri/calcite-components/components/calcite-list";
 import "@esri/calcite-components/components/calcite-list-item";
 import "@esri/calcite-components/components/calcite-list-item-group";
-import "@esri/calcite-components/components/calcite-navigation";
-import "@esri/calcite-components/components/calcite-navigation-logo";
 import "@esri/calcite-components/components/calcite-progress";
 import "@arcgis/map-components/components/arcgis-features";
 import "@arcgis/map-components/components/arcgis-legend";

--- a/2025/build-tooling/demo/final/vite.config.ts
+++ b/2025/build-tooling/demo/final/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
           {
             apiUrl: "/arcgis",
             delay: 400,
-            chaosRatio: 0.1,
+            chaosRatio: 0.5,
             // https://developers.arcgis.com/rest/places/near-point-get/#response
             chaosErrors: [400, 401, 403, 500],
           },

--- a/2025/build-tooling/slides.md
+++ b/2025/build-tooling/slides.md
@@ -19,7 +19,7 @@ is: feedback
 # Agenda
 
 - Introduction to build tools
-- Building an app (based on how Esri teams do it)
+- Building an app
   - Get started with Vite
   - Add dependencies
   - Use TypeScript and ESLint
@@ -211,7 +211,7 @@ These slides are built with Vite and hosted on GitHub Pages! ✨
 
 ---
 
-# Summary of demos
+# Demo summaries
 
 - **Vite ⚡** simplifies the development workflow
 - **React ⚛️** makes it easy to do complex things in a maintainable way
@@ -226,38 +226,57 @@ layout: intro
 
 # Enhance the app
 
+---
+
+# Lazy loading
+
+* Only load source files when needed
+* Split app into multiple entry points
+* Simplest split: by page or route
+
+---
+layout: center
+---
+
+# Demo: [Lazy loading & routes with React Router](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/6-routes)
 
 ---
 
-# DEMO: Add react-router
+# Testing
 
-- Show landing page with a link that loads the map page
-- Map is loaded lazily
-- Throughout, have code editor and dev server side by side to show off hot module replacement
+Testing is great, Vitest is also great!
+* Fast with familiar API
+* Supports modern language features
+* Run tests in Node or the browser
+* Direct integration with Vite
+
+---
+layout: center
+---
+
+# Demo: [Add tests with Vitest](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/7-tests)
 
 
 ---
 
-# Demo summary
+# Custom plugins
 
-- Optimize performance by splitting bundles
-- Quickly preview or debug builds, before they are deployed
+* Powerful way to enhance builds or developer workflows
+* Vite plugins are flexible and easy to write
+
+---
+layout: center
+---
+
+# Demo: [Add custom plugins](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/8-plugins)
 
 ---
 
-# DEMO: Add Vitest
+# Demo summaries
 
-- Vitest inherits Vite config - things "just work"
-- Showcase basic html snapshot test via Vitest browser mode
-
-
----
-
-# DEMO: Add custom plugins
-
-- Add JS API build plugin
-- Add chaos monkey development plugin
-
+- **Lazy loading ⚡** improves app performance
+- **Testing with Vitest 🦾** makes it easy to write and maintain tests
+- **Custom plugins 💎** provides a powerful way to enhance workflows
 
 ---
 

--- a/2025/build-tooling/slides.md
+++ b/2025/build-tooling/slides.md
@@ -261,8 +261,8 @@ layout: center
 
 # Custom plugins
 
-* Powerful way to enhance builds or developer workflows
 * Vite plugins are flexible and easy to write
+* Powerful way to enhance builds or developer workflows
 
 ---
 layout: center

--- a/2025/build-tooling/slides.md
+++ b/2025/build-tooling/slides.md
@@ -274,9 +274,9 @@ layout: center
 
 # Demo summaries
 
-- **Lazy loading ⚡** improves app performance
-- **Testing with Vitest 🦾** makes it easy to write and maintain tests
-- **Custom plugins 💎** provides a powerful way to enhance workflows
+- **Lazy loading 🚀** improves app performance
+- **Testing with Vitest 🧪** makes it easy to write and maintain tests
+- **Custom plugins 🔌** provides a powerful way to enhance workflows
 
 ---
 


### PR DESCRIPTION
* Adds intro / summary slides for my demos
* Removes unused web component imports
* Sets chaos monkey ratio to 0.5 - better for demoing
* Fix abort controller usage in chaos monkey demo
* Adjust slide spacing to more closely match the PPT template, and avoid text overlap with the corner graphics
* Update bullets to orange discs to match the PPT template