### PR TITLE
chore(2026-using-components-2): refresh info & dependencies

### DIFF
--- a/2026/build-tooling/README.md
+++ b/2026/build-tooling/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling
+# ArcGIS Maps SDK for JavaScript: Using Vite for Building Fast, Dynamic Web Apps
 
 Learn how Esri's development teams are leveraging modern tools like Vite to
 build fast, dynamic Web GIS applications. With features such as lazy loading,

--- a/2026/build-tooling/README.md
+++ b/2026/build-tooling/README.md
@@ -1,4 +1,4 @@
-# ArcGIS Maps SDK for JavaScript: Using Vite for Building Fast, Dynamic Web Apps
+# ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling
 
 Learn how Esri's development teams are leveraging modern tools like Vite to
 build fast, dynamic Web GIS applications. With features such as lazy loading,

--- a/2026/using-components-2/README.md
+++ b/2026/using-components-2/README.md
@@ -1,32 +1,33 @@
-# ArcGIS Maps SDK for JavaScript: App Development with Components part 2: Using Frameworks
+# ArcGIS Maps SDK for JavaScript: App Development with Components, Part 2: Using Frameworks
 
-Join us for the second session in our three-part series on building applications
-with the ArcGIS Maps SDK for JavaScript. This session will begin with exploring
-motivations for using frontend frameworks, and then will cover techniques for
-integrating the SDK's web components with frameworks and tools such as React and
-Vite. We will touch on current frontend methodologies for topics such as
-dependency management, asset management, semantic versioning, and conveniences
-offered by frameworks that streamline web mapping application development
-compared to plain JavaScript.
+Join us for the second technical session in a four-part series on building
+applications with the ArcGIS Maps SDK for JavaScript. Speakers begin with
+exploring motivations for using front-end frameworks and then cover techniques
+for integrating the SDK's web components with frameworks and tools such as React
+and Vite. The session touches on current front-end methodologies for topics such
+as dependency management, asset management, semantic versioning, prebuilt versus
+built applications that scale, and conveniences offered by frameworks that
+streamline web mapping app development compared to plain JavaScript.
 
-When: Wednesday, March 12 | 1:00 PM - 2:00 PM PDT
+When: Wednesday, March 11 | 1:00 PM - 2:00 PM PDT
 
-Where: Primrose B | Palm Springs Convention Center
+Where: Primrose A | Palm Springs Convention Center
 
 Presenters: [Omar Kawach](https://github.com/omarkawach) &
 [Max Patiiuk](https://github.com/maxpatiiuk) &
 [Nicholas Romano](https://github.com/nick-romano)
 
-Presented at [Esri Developer Summit 2025](https://devtechsummit2025.esri.com/).
+Presented at
+[Esri Dev & Tech Summit 2026](https://registration.esri.com/flow/esri/26epcdev/deveventportal/page/detailed-agenda/session/1761121225206001GaOj).
 
-[![ArcGIS Maps SDK for JavaScript: App Development with Components part 2: Using Frameworks header slide](./assets/header-slide.webp)](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2025/using-components-2)
+[![ArcGIS Maps SDK for JavaScript: App Development with Components part 2: Using Frameworks header slide](./assets/header-slide.webp)](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2026/using-components-2)
 
-[Slides](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2025/using-components-2)
-
+[Slides](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2026/using-components-2)
 See
-[Part 1](https://devtechsummit2025.esri.com/flow/esri/25epcdev/deveventportal/page/detailed-agenda/session/1730689428965001R0ur)
+[Part 1](https://registration.esri.com/flow/esri/26epcdev/deveventportal/page/detailed-agenda/session/1761121115055001AX1x),
+[Part 3](https://registration.esri.com/flow/esri/26epcdev/deveventportal/page/detailed-agenda/session/1761121324274001qsE7),
 and
-[Part 3](https://devtechsummit2025.esri.com/flow/esri/25epcdev/deveventportal/page/detailed-agenda/session/1730691473863001d3c1)
+[Part 4](https://registration.esri.com/flow/esri/26epcdev/deveventportal/page/detailed-agenda/session/1761122138829001Iinc)
 
 ## Resources
 

--- a/2026/using-components-2/demo/0-vanilla/README.md
+++ b/2026/using-components-2/demo/0-vanilla/README.md
@@ -5,7 +5,7 @@
 This is a base no-bundler sample that we will be enhancing today.
 
 See
-[Part 1](https://devtechsummit2025.esri.com/flow/esri/25epcdev/deveventportal/page/detailed-agenda/session/1730689428965001R0ur)
+[Part 1](https://registration.esri.com/flow/esri/26epcdev/deveventportal/page/detailed-agenda/session/1761121115055001AX1x)
 of this series for more details.
 
 ## Technologies used:
@@ -22,7 +22,7 @@ of this series for more details.
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/using-components-2/demo/0-vanilla
+   cd esri-dev-summit-presentations/2026/using-components-2/demo/0-vanilla
    ```
 
 2. Open index.html in the browser

--- a/2026/using-components-2/demo/0-vanilla/index.html
+++ b/2026/using-components-2/demo/0-vanilla/index.html
@@ -5,19 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Elevation Profiles of National Park Trails</title>
     <link rel="icon" href="data:;base64,=" />
-    <script
-      type="module"
-      src="https://js.arcgis.com/calcite-components/3.0.3/calcite.esm.js"
-    ></script>
-    <link
-      rel="stylesheet"
-      href="https://js.arcgis.com/4.32/esri/themes/light/main.css"
-    />
-    <script src="https://js.arcgis.com/4.32/"></script>
-    <script
-      type="module"
-      src="https://js.arcgis.com/map-components/4.32/arcgis-map-components.esm.js"
-    ></script>
+    <script src="https://js.arcgis.com/5.0/"></script>
     <style>
       /** Custom branding */
       calcite-shell.custom-theme {

--- a/2026/using-components-2/demo/1-javascript/README.md
+++ b/2026/using-components-2/demo/1-javascript/README.md
@@ -19,7 +19,7 @@ The project was created using the [Vite sample app in jsapi-resources](https://g
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/using-components-2/demo/1-javascript
+   cd esri-dev-summit-presentations/2026/using-components-2/demo/1-javascript
    ```
 
 2. Install dependencies

--- a/2026/using-components-2/demo/1-javascript/package.json
+++ b/2026/using-components-2/demo/1-javascript/package.json
@@ -8,11 +8,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.32.0",
-    "@arcgis/map-components": "~4.32.0",
-    "@esri/calcite-components": "^3.0.3"
+    "@arcgis/core": "^5.0.0-next.62",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38"
   },
   "devDependencies": {
-    "vite": "^6.1.1"
+    "vite": "^7.3.0"
   }
 }

--- a/2026/using-components-2/demo/1-javascript/src/styles.css
+++ b/2026/using-components-2/demo/1-javascript/src/styles.css
@@ -1,7 +1,3 @@
-@import "https://js.arcgis.com/calcite-components/3.0.3/calcite.css";
-@import "https://js.arcgis.com/4.32/@arcgis/core/assets/esri/themes/dark/main.css";
-@import "https://js.arcgis.com/map-components/4.32/arcgis-map-components.css";
-
 /** Custom branding */
 calcite-shell.custom-theme {
   --calcite-color-brand: #308e29;

--- a/2026/using-components-2/demo/2-react/README.md
+++ b/2026/using-components-2/demo/2-react/README.md
@@ -24,7 +24,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/using-components-2/demo/2-react
+   cd esri-dev-summit-presentations/2026/using-components-2/demo/2-react
    ```
 
 2. Install dependencies

--- a/2026/using-components-2/demo/2-react/package.json
+++ b/2026/using-components-2/demo/2-react/package.json
@@ -8,14 +8,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.32.0",
-    "@arcgis/map-components": "~4.32.0",
-    "@esri/calcite-components": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@arcgis/core": "^5.0.0-next.62",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "vite": "^6.1.1"
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "vite": "^7.3.0"
   }
 }

--- a/2026/using-components-2/demo/2-react/src/styles.css
+++ b/2026/using-components-2/demo/2-react/src/styles.css
@@ -1,7 +1,3 @@
-@import "https://js.arcgis.com/calcite-components/3.0.3/calcite.css";
-@import "https://js.arcgis.com/4.32/@arcgis/core/assets/esri/themes/dark/main.css";
-@import "https://js.arcgis.com/map-components/4.32/arcgis-map-components.css";
-
 /** Custom branding */
 calcite-shell.custom-theme {
   --calcite-color-brand: #308e29;

--- a/2026/using-components-2/demo/3-typescript/README.md
+++ b/2026/using-components-2/demo/3-typescript/README.md
@@ -23,7 +23,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/using-components-2/demo/3-typescript
+   cd esri-dev-summit-presentations/2026/using-components-2/demo/3-typescript
    ```
 
 2. Install dependencies

--- a/2026/using-components-2/demo/3-typescript/package.json
+++ b/2026/using-components-2/demo/3-typescript/package.json
@@ -8,17 +8,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.32.0",
-    "@arcgis/map-components": "~4.32.0",
-    "@esri/calcite-components": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@arcgis/core": "^5.0.0-next.62",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "typescript": "5.8.2",
-    "vite": "^6.1.1"
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "typescript": "5.9.3",
+    "vite": "^7.3.0"
   }
 }

--- a/2026/using-components-2/demo/3-typescript/src/styles.css
+++ b/2026/using-components-2/demo/3-typescript/src/styles.css
@@ -1,7 +1,3 @@
-@import "https://js.arcgis.com/calcite-components/3.0.3/calcite.css";
-@import "https://js.arcgis.com/4.32/@arcgis/core/assets/esri/themes/dark/main.css";
-@import "https://js.arcgis.com/map-components/4.32/arcgis-map-components.css";
-
 /** Custom branding */
 calcite-shell.custom-theme {
   --calcite-color-brand: #308e29;

--- a/2026/using-components-2/demo/3-typescript/src/vite-env.d.ts
+++ b/2026/using-components-2/demo/3-typescript/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
-/// <reference types="@esri/calcite-components/dist/types/react" />
-/// <reference types="@arcgis/map-components/dist/types/react" />
+/// <reference types="@esri/calcite-components/types/react" />
+/// <reference types="@arcgis/map-components/types/react" />

--- a/2026/using-components-2/demo/3-typescript/tsconfig.json
+++ b/2026/using-components-2/demo/3-typescript/tsconfig.json
@@ -7,14 +7,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "baseUrl": "./"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/2026/using-components-2/demo/4-typescript-add-minimap/README.md
+++ b/2026/using-components-2/demo/4-typescript-add-minimap/README.md
@@ -23,7 +23,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/using-components-2/demo/4-typescript-add-minimap
+   cd esri-dev-summit-presentations/2026/using-components-2/demo/4-typescript-add-minimap
    ```
 
 2. Install dependencies

--- a/2026/using-components-2/demo/4-typescript-add-minimap/package.json
+++ b/2026/using-components-2/demo/4-typescript-add-minimap/package.json
@@ -8,17 +8,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.32.0",
-    "@arcgis/map-components": "~4.32.0",
-    "@esri/calcite-components": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@arcgis/core": "^5.0.0-next.62",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "vite": "^6.1.1",
-    "@vitejs/plugin-react": "^4.3.4",
-    "typescript": "5.8.2",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4"
+    "vite": "^7.3.0",
+    "@vitejs/plugin-react": "^5.1.2",
+    "typescript": "5.9.3",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3"
   }
 }

--- a/2026/using-components-2/demo/4-typescript-add-minimap/src/styles.css
+++ b/2026/using-components-2/demo/4-typescript-add-minimap/src/styles.css
@@ -1,7 +1,3 @@
-@import "https://js.arcgis.com/calcite-components/3.0.3/calcite.css";
-@import "https://js.arcgis.com/4.32/@arcgis/core/assets/esri/themes/dark/main.css";
-@import "https://js.arcgis.com/map-components/4.32/arcgis-map-components.css";
-
 /** Custom branding */
 calcite-shell.custom-theme {
   --calcite-color-brand: #308e29;

--- a/2026/using-components-2/demo/4-typescript-add-minimap/src/vite-env.d.ts
+++ b/2026/using-components-2/demo/4-typescript-add-minimap/src/vite-env.d.ts
@@ -1,3 +1,3 @@
 /// <reference types="vite/client" />
-/// <reference types="@esri/calcite-components/dist/types/react" />
-/// <reference types="@arcgis/map-components/dist/types/react" />
+/// <reference types="@esri/calcite-components/types/react" />
+/// <reference types="@arcgis/map-components/types/react" />

--- a/2026/using-components-2/demo/4-typescript-add-minimap/tsconfig.json
+++ b/2026/using-components-2/demo/4-typescript-add-minimap/tsconfig.json
@@ -7,14 +7,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "baseUrl": "./"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/2026/using-components-2/slides.md
+++ b/2026/using-components-2/slides.md
@@ -180,7 +180,7 @@ package.json:
 
 ```json
   // Required for the app to run
-   "dependencies": {
+  "dependencies": {
     "@arcgis/map-components": "^5.0.0-next.99",
     "@esri/calcite-components": "^5.0.0-next.38",
     "react": "^19.2.3",

--- a/2026/using-components-2/slides.md
+++ b/2026/using-components-2/slides.md
@@ -180,19 +180,19 @@ package.json:
 
 ```json
   // Required for the app to run
-  "dependencies": {
-    "@arcgis/map-components": "~5.0.0",
-    "@esri/calcite-components": "^5.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+   "dependencies": {
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   // Only used during development/build
   "devDependencies": {
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "typescript": "^5.8.2",
-    "vite": "^6.1.0"
+    "vite": "^7.3.0",
+    "typescript": "5.9.3",
+    "@vitejs/plugin-react": "^5.1.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3"
   }
 ```
 
@@ -200,7 +200,7 @@ package.json:
 
 # Semantic versioning
 
-`<major>.<minor>.<patch>` (example: `3.0.3`)
+`<major>.<minor>.<patch>` (example: `5.0.0`)
 
 - **major**: breaking changes - read the release notes
 - **minor**: new features - safe to update
@@ -213,19 +213,10 @@ package.json:
 Rather than specifying an exact version, you can let NPM decide which version to
 install:
 
-- `^3.0.3` - any version from 3.0.3 to 4.0.0 (features and bug fixes)
-- `~3.0.3` - any version from 3.0.3 to 3.1.0 (only bug fixes)
+- `^5.0.0` - any version from 5.0.0 to 6.0.0 (features and bug fixes)
+- `~5.0.0` - any version from 5.0.0 to 5.1.0 (only bug fixes)
 
 Allows for dependency sharing (multiple packages can use single Calcite)
-
----
-
-# Exceptions to semantic versioning
-
-- `@arcgis/*` - follows `4.<major>.<patch>` instead
-  - Use `~` over `^` for such packages
-- `typescript` - does not follow semantic versioning - any version can have
-  breaking changes
 
 ---
 
@@ -494,17 +485,6 @@ layout: center
 
 ---
 
-# Framework specific component wrappers
-
-- React 18 wrapper package for our components
-  - npm: `@arcgis/map-components-react`
-  - Encourage you to use React 19 going forward where no wrapper is needed
-
-- Calcite React 18 wrapper
-  - npm: `@esri/calcite-components-react`
-
----
-
 # Other frameworks
 
 - Angular and Vue also support web components.
@@ -515,40 +495,41 @@ layout: center
 
 ---
 
-# Vite deep dive session (today in 2 hrs)
-
-Deeper Vite and Vitest guide - shows how Esri is building apps
-
-**When**: Today (Wednesday, March 12) | 4:00 PM - 5:00 PM PDT
-
-**Where**: Smoketree C | Palm Springs Convention Center
-
-> Learn how Esri's development teams are leveraging modern tools like Vite to
-> build fast, dynamic Web GIS applications. With features such as lazy loading,
-> client-side routing, hot module replacement, and lightning-fast builds, Vite
-> streamlines the entire development workflow from bundling to deployment.
-> Paired with Vitest for testing, these tools help ensure that your apps are
-> both high-performing and production-ready.
-
----
-
 # Next session
 
-App Development with Components Part 3: User Experience (Deeper Calcite UX best
-practices)
+ArcGIS Maps SDK for JavaScript: App Development with Components, Part 3: User
+Experience (Deeper Calcite UX best practices)
 
-**When**: Tomorrow (Thursday, March 13) | 1:00 PM - 2:00 PM PDT
+**When**: Tomorrow (Thursday, March 13) | 10:30 AM - 11:30 AM PDT
 
 **Where**: Primrose A | Palm Springs Convention Center
 
-> Join us for the third session in our three-part series on building
-> applications with the ArcGIS Maps SDK for JavaScript. This session is focused
-> on building the user experience in your web app with the SDK's components and
+> Join us for the third technical session in a four-part series on building
+> applications with the ArcGIS Maps SDK for JavaScript. This session focuses on
+> building the user experience in your web app with the SDK's components and
 > Calcite Design System. Calcite provides a library of patterns, icons, and
-> user-friendly, configurable web components that enable developers to easily
-> build responsive, accessible web applications. We'll demonstrate how the
+> user-friendly, configurable web components that enable you to easily build
+> responsive, accessible web applications. Speakers demonstrate how the
 > components can be used together to build intuitive yet powerful experiences in
 > your apps.
+
+---
+
+# ArcGIS Maps SDK for JavaScript: Using Vite for Building Fast, Dynamic Web Apps (tomorrow)
+
+Deeper Vite and Vitest guide - shows how Esri is building apps
+
+**When**: Tomorrow (Wednesday, March 12) | 4:00 PM - 5:00 PM PDT
+
+**Where**: Mohave Learning Center | Palm Springs Convention Center
+
+> This technical session explores a case study on how Esri's development teams
+> are leveraging modern tools like Vite to build fast, dynamic web GIS
+> applications. With features such as lazy loading, client-side routing, hot
+> module replacement, and lightning-fast builds, Vite streamlines the entire
+> development workflow from bundling to deployment. Paired with Vitest for
+> testing, these tools help ensure that your apps are both high-performing and
+> production-ready.
 
 ---
 layout: center
@@ -556,7 +537,7 @@ layout: center
 
 # Questions?
 
-ArcGIS Maps SDK for JavaScript: App Development with Components part 2: Using
+ArcGIS Maps SDK for JavaScript: App Development with Components, Part 2: Using
 Frameworks
 
 Demos and additional resources available at:

--- a/2026/using-components-2/slides.md
+++ b/2026/using-components-2/slides.md
@@ -1,13 +1,13 @@
 ---
 titleTemplate: '%s'
-author: Omar Kawach, Max Patiiuk
+author: Omar Kawach, Max Patiiuk, Nicholas Romano
 mdc: true
 colorSchema: dark
 ---
 
-## ArcGIS Maps SDK for JavaScript:<br>App Development with Components<br>part 2: Using Frameworks
+## ArcGIS Maps SDK for JavaScript: App Development with Components,<br>Part 2: Using Frameworks
 
-Omar Kawach, Max Patiiuk, Nick Romano
+Omar Kawach, Max Patiiuk, Nicholas Romano
 
 ---
 is: feedback
@@ -35,7 +35,7 @@ build on top of each other
 
 # Today's session
 
-2nd in a 3-part series
+2nd in a 4-part series
 
 - We will cover:
   - Calcite
@@ -155,7 +155,7 @@ graph LR
 layout: center
 ---
 
-# Demo: [Get started with Vite](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/using-components-2/demo/1-javascript)
+# Demo: [Get started with Vite](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/using-components-2/demo/1-javascript)
 
 <!--
 - Describe converting index.html app to Vite
@@ -181,8 +181,8 @@ package.json:
 ```json
   // Required for the app to run
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
-    "@esri/calcite-components": "^3.0.3",
+    "@arcgis/map-components": "~5.0.0",
+    "@esri/calcite-components": "^5.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -293,7 +293,7 @@ layout: intro
 layout: center
 ---
 
-# Demo: [Get started with React](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/using-components-2/demo/2-react)
+# Demo: [Get started with React](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/using-components-2/demo/2-react)
 
 <!--
 - show differences to file extension
@@ -472,7 +472,7 @@ Declarative rendering makes it easier to understand what the component will look
 layout: center
 ---
 
-# Demo: [Get started with React + TypeScript](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/using-components-2/demo/3-typescript)
+# Demo: [Get started with React + TypeScript](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/using-components-2/demo/3-typescript)
 
 <!--
 - Show tsconfig
@@ -497,7 +497,6 @@ layout: center
 # Framework specific component wrappers
 
 - React 18 wrapper package for our components
-
   - npm: `@arcgis/map-components-react`
   - Encourage you to use React 19 going forward where no wrapper is needed
 


### PR DESCRIPTION
Update session metadata

Update dependencies in demos

Update typescript config

Update usages of our libraries (use the not-yet-released single script cdn, drop redundant css imports). Once 5.0 is out, we should update to use the non-next version of dependencies

Yann is working on a new demo app - we will use that once it is available