### PR TITLE
chore(2026-build-tooling): refresh info & dependencies

### DIFF
--- a/2026/build-tooling/README.md
+++ b/2026/build-tooling/README.md
@@ -11,7 +11,7 @@ When: Thursday, March 12 | 4:00 PM - 5:00 PM PDT
 
 Where: Mohave Learning Center | Palm Springs Convention Center
 
-Presenters: [Max Payson](https://github.com/mpayson) &
+Presenters: [Hugo Campos](https://bsky.app/profile/hugocampos.bsky.social) &
 [Max Patiiuk](https://github.com/maxpatiiuk)
 
 Presented at [Esri Developer Summit 2026](https://devtechsummit2026.esri.com/).

--- a/2026/build-tooling/README.md
+++ b/2026/build-tooling/README.md
@@ -1,31 +1,31 @@
-# ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling
+# ArcGIS Maps SDK for JavaScript: Using Vite for Building Fast, Dynamic Web Apps
 
-Learn how Esri's development teams are leveraging modern tools like Vite to
-build fast, dynamic Web GIS applications. With features such as lazy loading,
-client-side routing, hot module replacement, and lightning-fast builds, Vite
-streamlines the entire development workflow from bundling to deployment. Paired
-with Vitest for testing, these tools help ensure that your apps are both
-high-performing and production-ready.
+This technical session explores a case study on how Esri's development teams are
+leveraging modern tools like Vite to build fast, dynamic web GIS applications.
+With features such as lazy loading, client-side routing, hot module replacement,
+and lightning-fast builds, Vite streamlines the entire development workflow from
+bundling to deployment. Paired with Vitest for testing, these tools help ensure
+that your apps are both high-performing and production-ready.
 
-When: Wednesday, March 12 | 4:00 PM - 5:00 PM PDT
+When: Thursday, March 12 | 4:00 PM - 5:00 PM PDT
 
-Where: Smoketree C | Palm Springs Convention Center
+Where: Mohave Learning Center | Palm Springs Convention Center
 
 Presenters: [Max Payson](https://github.com/mpayson) &
 [Max Patiiuk](https://github.com/maxpatiiuk)
 
-Presented at [Esri Developer Summit 2025](https://devtechsummit2025.esri.com/).
+Presented at [Esri Developer Summit 2026](https://devtechsummit2026.esri.com/).
 
-[![ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling header slide](./assets/header-slide.webp)](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2025/build-tooling)
+[![ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling header slide](./assets/header-slide.webp)](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2026/build-tooling)
 
-[Slides](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2025/build-tooling)
+[Slides](https://maxpatiiuk.github.io/esri-dev-summit-presentations/2026/build-tooling)
 
 ## Resources
 
 ### Vite ⚡
 
 - [Final demo app](./demo/final)
-- [Basic demo apo](./demo/1-javascript)
+- [Basic demo app](./demo/1-javascript)
   - Run `npm create vite` to create a new Vite project
 - [Documentation](https://vitejs.dev/)
   - [Publishing guide](https://vite.dev/guide/static-deploy)

--- a/2026/build-tooling/demo/1-javascript/README.md
+++ b/2026/build-tooling/demo/1-javascript/README.md
@@ -14,7 +14,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/1-javascript
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/1-javascript
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/1-javascript/package.json
+++ b/2026/build-tooling/demo/1-javascript/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "vite": "^6.1.0"
+    "vite": "^7.3.0"
   }
 }

--- a/2026/build-tooling/demo/2-react/README.md
+++ b/2026/build-tooling/demo/2-react/README.md
@@ -28,7 +28,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/2-react
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/2-react
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/2-react/package.json
+++ b/2026/build-tooling/demo/2-react/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "vite": "^6.1.0"
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "vite": "^7.3.0"
   }
 }

--- a/2026/build-tooling/demo/3-web-components/README.md
+++ b/2026/build-tooling/demo/3-web-components/README.md
@@ -11,7 +11,7 @@ Based on [Calcite get started](https://developers.arcgis.com/calcite-design-syst
   npm install @esri/calcite-components @arcgis/map-components
   ```
 - Import their styles in [src/index.css](./src/index.css)
-- import `<calcite-link` and use it in [src/Splash.jsx](./src/Splash.jsx)
+- import `<calcite-link>` and use it in [src/Splash.jsx](./src/Splash.jsx)
 
 ## Technologies used:
 
@@ -28,7 +28,7 @@ Based on [Calcite get started](https://developers.arcgis.com/calcite-design-syst
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/3-web-components
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/3-web-components
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/3-web-components/package.json
+++ b/2026/build-tooling/demo/3-web-components/package.json
@@ -9,13 +9,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
-    "@esri/calcite-components": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "vite": "^6.1.0"
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "vite": "^7.3.0"
   }
 }

--- a/2026/build-tooling/demo/3-web-components/src/index.css
+++ b/2026/build-tooling/demo/3-web-components/src/index.css
@@ -1,8 +1,3 @@
-/* Import styles for Calcite components, ArcGIS Core, and map components */
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/4-typescript/README.md
+++ b/2026/build-tooling/demo/4-typescript/README.md
@@ -49,7 +49,7 @@ Tips:
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/4-typescript
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/4-typescript
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/4-typescript/src/index.css
+++ b/2026/build-tooling/demo/4-typescript/src/index.css
@@ -1,8 +1,3 @@
-/* Import styles for Calcite components, ArcGIS Core, and map components */
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/4-typescript/tsconfig.json
+++ b/2026/build-tooling/demo/4-typescript/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ES2022",
+    "target": "ES2024",
     "useDefineForClassFields": true,
     "skipLibCheck": true
   }

--- a/2026/build-tooling/demo/5-eslint/README.md
+++ b/2026/build-tooling/demo/5-eslint/README.md
@@ -47,7 +47,7 @@ Tip:
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/5-eslint
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/5-eslint
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/5-eslint/package.json
+++ b/2026/build-tooling/demo/5-eslint/package.json
@@ -9,22 +9,22 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
-    "@esri/calcite-components": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^16.0.0",
-    "typescript": "^5.8.2",
-    "typescript-eslint": "^8.26.0",
-    "vite": "^6.1.0"
+    "@eslint/js": "^9.39.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^16.5.0",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.50.1",
+    "vite": "^7.3.0"
   }
 }

--- a/2026/build-tooling/demo/5-eslint/src/index.css
+++ b/2026/build-tooling/demo/5-eslint/src/index.css
@@ -1,8 +1,3 @@
-/* Import styles for Calcite components, ArcGIS Core, and map components */
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/5-eslint/tsconfig.json
+++ b/2026/build-tooling/demo/5-eslint/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ES2022",
+    "target": "ES2024",
     "useDefineForClassFields": true,
     "skipLibCheck": true
   }

--- a/2026/build-tooling/demo/6-routes/README.md
+++ b/2026/build-tooling/demo/6-routes/README.md
@@ -20,7 +20,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/6-routes
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/6-routes
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/6-routes/package.json
+++ b/2026/build-tooling/demo/6-routes/package.json
@@ -13,24 +13,24 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
-    "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router": "^7.2.0"
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router": "^7.11.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0-canary-8a7b487e-20250218",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
-    "prettier": "^3.5.1",
-    "typescript": "^5.7.3",
-    "typescript-eslint": "^8.24.1",
-    "vite": "^6.1.0"
+    "@eslint/js": "^9.39.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^16.5.0",
+    "prettier": "^3.7.4",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.50.1",
+    "vite": "^7.3.0"
   }
 }

--- a/2026/build-tooling/demo/6-routes/src/index.css
+++ b/2026/build-tooling/demo/6-routes/src/index.css
@@ -1,7 +1,3 @@
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/6-routes/tsconfig.json
+++ b/2026/build-tooling/demo/6-routes/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ES2022",
+    "target": "ES2024",
     "useDefineForClassFields": true,
     "skipLibCheck": true
   }

--- a/2026/build-tooling/demo/7-testing/README.md
+++ b/2026/build-tooling/demo/7-testing/README.md
@@ -20,7 +20,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/7-testing
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/7-testing
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/7-testing/package.json
+++ b/2026/build-tooling/demo/7-testing/package.json
@@ -13,30 +13,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
     "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router": "^7.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router": "^7.11.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "@vitest/browser": "^3.0.7",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0-canary-8a7b487e-20250218",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
-    "msw": "^2.7.3",
-    "playwright": "^1.50.1",
-    "prettier": "^3.5.1",
-    "typescript": "^5.7.3",
-    "typescript-eslint": "^8.24.1",
-    "vite": "^6.1.0",
-    "vitest": "^3.0.7"
+    "@eslint/js": "^9.39.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "@vitest/browser": "^4.0.16",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^16.5.0",
+    "msw": "^2.12.4",
+    "playwright": "^1.57.0",
+    "prettier": "^3.7.4",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.50.1",
+    "vite": "^7.3.0",
+    "vitest": "^4.0.16"
   }
 }

--- a/2026/build-tooling/demo/7-testing/src/index.css
+++ b/2026/build-tooling/demo/7-testing/src/index.css
@@ -1,7 +1,3 @@
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/7-testing/tsconfig.json
+++ b/2026/build-tooling/demo/7-testing/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ES2022",
+    "target": "ES2024",
     "useDefineForClassFields": true,
     "skipLibCheck": true
   }

--- a/2026/build-tooling/demo/8-plugins/README.md
+++ b/2026/build-tooling/demo/8-plugins/README.md
@@ -20,7 +20,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/8-plugins
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/8-plugins
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/8-plugins/package.json
+++ b/2026/build-tooling/demo/8-plugins/package.json
@@ -13,30 +13,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
     "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router": "^7.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router": "^7.11.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "@vitest/browser": "^3.0.7",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0-canary-8a7b487e-20250218",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
-    "msw": "^2.7.3",
-    "playwright": "^1.50.1",
-    "prettier": "^3.5.1",
-    "typescript": "^5.7.3",
-    "typescript-eslint": "^8.24.1",
-    "vite": "^6.1.0",
-    "vitest": "^3.0.7"
+    "@eslint/js": "^9.39.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "@vitest/browser": "^4.0.16",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^16.5.0",
+    "msw": "^2.12.4",
+    "playwright": "^1.57.0",
+    "prettier": "^3.7.4",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.50.1",
+    "vite": "^7.3.0",
+    "vitest": "^4.0.16"
   }
 }

--- a/2026/build-tooling/demo/8-plugins/src/index.css
+++ b/2026/build-tooling/demo/8-plugins/src/index.css
@@ -1,7 +1,3 @@
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/8-plugins/tsconfig.json
+++ b/2026/build-tooling/demo/8-plugins/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ES2022",
+    "target": "ES2024",
     "useDefineForClassFields": true,
     "skipLibCheck": true
   }

--- a/2026/build-tooling/demo/final/README.md
+++ b/2026/build-tooling/demo/final/README.md
@@ -20,7 +20,7 @@
 
    ```sh
    git clone https://github.com/maxpatiiuk/esri-dev-summit-presentations esri-dev-summit-presentations
-   cd esri-dev-summit-presentations/2025/build-tooling/demo/final
+   cd esri-dev-summit-presentations/2026/build-tooling/demo/final
    ```
 
 2. Install dependencies

--- a/2026/build-tooling/demo/final/package.json
+++ b/2026/build-tooling/demo/final/package.json
@@ -13,30 +13,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
+    "@arcgis/map-components": "^5.0.0-next.99",
+    "@esri/calcite-components": "^5.0.0-next.38",
     "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router": "^7.2.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
+    "react-router": "^7.11.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.20.0",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/react": "^16.2.0",
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "@vitest/browser": "^3.0.7",
-    "eslint-plugin-react": "^7.37.4",
-    "eslint-plugin-react-hooks": "^5.2.0-canary-8a7b487e-20250218",
-    "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^15.15.0",
-    "msw": "^2.7.3",
-    "playwright": "^1.50.1",
-    "prettier": "^3.5.1",
-    "typescript": "^5.7.3",
-    "typescript-eslint": "^8.24.1",
-    "vite": "^6.1.0",
-    "vitest": "^3.0.7"
+    "@eslint/js": "^9.39.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.2",
+    "@vitest/browser": "^4.0.16",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-refresh": "^0.4.26",
+    "globals": "^16.5.0",
+    "msw": "^2.12.4",
+    "playwright": "^1.57.0",
+    "prettier": "^3.7.4",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.50.1",
+    "vite": "^7.3.0",
+    "vitest": "^4.0.16"
   }
 }

--- a/2026/build-tooling/demo/final/src/index.css
+++ b/2026/build-tooling/demo/final/src/index.css
@@ -1,7 +1,3 @@
-@import "@esri/calcite-components/calcite/calcite.css";
-@import "@arcgis/core/assets/esri/themes/light/main.css";
-@import "@arcgis/map-components/arcgis-map-components/arcgis-map-components.css";
-
 html,
 body,
 #root {

--- a/2026/build-tooling/demo/final/tsconfig.json
+++ b/2026/build-tooling/demo/final/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "target": "ES2022",
+    "target": "ES2024",
     "useDefineForClassFields": true,
     "skipLibCheck": true
   }

--- a/2026/build-tooling/slides.md
+++ b/2026/build-tooling/slides.md
@@ -5,7 +5,7 @@ mdc: true
 colorSchema: dark
 ---
 
-## ArcGIS Maps SDK for JavaScript:<br>Fast Development and Build Tooling
+## ArcGIS Maps SDK for JavaScript:<br>Using Vite for Building Fast, Dynamic Web Apps
 
 Max Patiiuk, Max Payson
 
@@ -94,7 +94,7 @@ graph LR
 layout: center
 ---
 
-# Demo: [Get started with Vite](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/1-javascript)
+# Demo: [Get started with Vite](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/1-javascript)
 
 <!--
 - Create a Vite starter project
@@ -119,7 +119,7 @@ layout: center
 layout: center
 ---
 
-# Demo: [Add basic React 19](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/2-react)
+# Demo: [Add basic React 19](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/2-react)
 
 ---
 
@@ -133,7 +133,7 @@ layout: center
 layout: center
 ---
 
-# Demo: [Add Calcite and JS Maps SDK components](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/3-web-components)
+# Demo: [Add Calcite and JS Maps SDK components](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/3-web-components)
 
 ---
 
@@ -157,7 +157,7 @@ project.
 layout: center
 ---
 
-# Demo: [Adopt TypeScript](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/4-typescript)
+# Demo: [Adopt TypeScript](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/4-typescript)
 
 ---
 
@@ -172,7 +172,7 @@ layout: center
 layout: center
 ---
 
-# Demo: [Use ESLint](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/5-eslint)
+# Demo: [Use ESLint](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/5-eslint)
 
 ---
 
@@ -249,7 +249,7 @@ layout: intro
 layout: center
 ---
 
-# Demo: [Lazy loading & routes with React Router](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/6-routes)
+# Demo: [Lazy loading & routes with React Router](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/6-routes)
 
 ---
 
@@ -266,7 +266,7 @@ Testing is great, Vitest is also great!
 layout: center
 ---
 
-# Demo: [Add tests with Vitest](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/7-tests)
+# Demo: [Add tests with Vitest](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/7-tests)
 
 ---
 
@@ -279,7 +279,7 @@ layout: center
 layout: center
 ---
 
-# Demo: [Add custom plugins](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2025/build-tooling/demo/8-plugins)
+# Demo: [Add custom plugins](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/8-plugins)
 
 ---
 
@@ -307,7 +307,7 @@ layout: center
 ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling
 
 Demos and additional resources available at:
-[arcg.is/esri-2025-build-tooling](https://arcg.is/esri-2025-build-tooling)
+[arcg.is/esri-2026-build-tooling](https://arcg.is/esri-2026-build-tooling)
 
 <img src="./assets/qr-code.svg" alt="" style="margin: 0 auto">
 

--- a/2026/build-tooling/slides.md
+++ b/2026/build-tooling/slides.md
@@ -1,13 +1,13 @@
 ---
 titleTemplate: '%s'
-author: Max Payson, Max Patiiuk
+author: Hugo Campos, Max Patiiuk
 mdc: true
 colorSchema: dark
 ---
 
 ## ArcGIS Maps SDK for JavaScript:<br>Using Vite for Building Fast, Dynamic Web Apps
 
-Max Patiiuk, Max Payson
+Hugo Campos, Max Patiiuk
 
 ---
 is: feedback


### PR DESCRIPTION
Update session metadata

Update dependencies in demos

Update typescript config

Update usages of our libraries (drop redundant css imports). Once 5.0 is out, we should update to use the non-next version of dependencies