### PR TITLE
style(2026): use light theme only

### DIFF
--- a/2026/.meta/shiki.js
+++ b/2026/.meta/shiki.js
@@ -1,0 +1,12 @@
+import { defineShikiSetup } from '@slidev/types';
+
+export default defineShikiSetup(() => {
+  return {
+    themes: {
+      // This theme has higher contrast than the default light theme
+      // There is also github-light-high-contrast, but it makes colors too dark
+      // to see the differences between the syntaxes, reducing readability
+      light: 'github-light',
+    },
+  };
+});

--- a/2026/.meta/styles.css
+++ b/2026/.meta/styles.css
@@ -1,8 +1,31 @@
-#page-root {
-  --slidev-code-background: #1118;
+:root {
+  /* Disable Chrome auto dark mode */
+  color-scheme: only light;
+}
 
+#page-root {
+  /*
+   * While code blocks are in light mode, the slide background is darker so
+   * slide text defaults to white
+   */
   color: white;
+  /* Match presentation template */
   font-family: Arial;
+}
+
+/** Force light mode for code blocks */
+.slidev-note :not(pre) > code,
+.slidev-layout :not(pre) > code {
+  background: #fffb;
+  color: black;
+}
+
+#slide-content {
+  /*
+   * The background image is 1px too short. To avoid a 1px white line, make
+   * background invisible
+   */
+  background: black;
 }
 
 .slidev-layout {
@@ -50,4 +73,6 @@
 .mermaid {
   display: flex;
   justify-content: center;
+  background: white;
+  border-radius: 0.5rem;
 }

--- a/2026/a-look-under-the-hood/setup/shiki.js
+++ b/2026/a-look-under-the-hood/setup/shiki.js
@@ -1,0 +1,1 @@
+export * from '../../.meta/shiki';

--- a/2026/a-look-under-the-hood/slides.md
+++ b/2026/a-look-under-the-hood/slides.md
@@ -2,7 +2,7 @@
 titleTemplate: '%s'
 author: Thorben Westerhuys, Max Patiiuk
 mdc: true
-colorSchema: dark
+colorSchema: light
 ---
 
 ## ArcGIS Maps SDK for JavaScript:<br>A Look Under the Hood

--- a/2026/build-tooling/setup/shiki.js
+++ b/2026/build-tooling/setup/shiki.js
@@ -1,0 +1,1 @@
+export * from '../../.meta/shiki';

--- a/2026/build-tooling/slides.md
+++ b/2026/build-tooling/slides.md
@@ -2,7 +2,7 @@
 titleTemplate: '%s'
 author: Hugo Campos, Max Patiiuk
 mdc: true
-colorSchema: dark
+colorSchema: light
 ---
 
 ## ArcGIS Maps SDK for JavaScript:<br>Using Vite for Building Fast, Dynamic Web Apps

--- a/2026/using-components-2/setup/shiki.js
+++ b/2026/using-components-2/setup/shiki.js
@@ -1,0 +1,1 @@
+export * from '../../.meta/shiki';

--- a/2026/using-components-2/slides.md
+++ b/2026/using-components-2/slides.md
@@ -2,7 +2,7 @@
 titleTemplate: '%s'
 author: Omar Kawach, Max Patiiuk, Nicholas Romano
 mdc: true
-colorSchema: dark
+colorSchema: light
 ---
 
 ## ArcGIS Maps SDK for JavaScript: App Development with Components,<br>Part 2: Using Frameworks

--- a/2026/vis-techniques-3d/setup/shiki.js
+++ b/2026/vis-techniques-3d/setup/shiki.js
@@ -1,0 +1,1 @@
+export * from '../../.meta/shiki';

--- a/2026/vis-techniques-3d/slides.md
+++ b/2026/vis-techniques-3d/slides.md
@@ -2,7 +2,7 @@
 titleTemplate: '%s'
 author: Hugo Campos, Thorben Westerhuys
 mdc: true
-colorSchema: dark
+colorSchema: light
 # slide transition: https://sli.dev/guide/animations.html#slide-transitions
 transition: view-transition
 fonts:


### PR DESCRIPTION
Force use light theme only in our slides.

Per feedback received last year.

This is because light theme has higher contrast on the projectors.

I reviewed that all 2026/ presentations look good after these changes