### PR TITLE
fix(2026-vis-techniques-3d): fix image references

### DIFF
--- a/2026/vis-techniques-3d/slides.md
+++ b/2026/vis-techniques-3d/slides.md
@@ -289,7 +289,7 @@ const map = new WebScene({
 const view = new SceneView({ map });
 ```
 
-<img v-click="1" src="./basemaps-list.avif">
+<img v-click="1" src="/basemaps-list.avif">
 
 <!--
 Use of these basemaps requires either an ArcGIS Location Platform account, ArcGIS Online organizational subscription, or an ArcGIS Enterprise license.
@@ -495,7 +495,7 @@ const layer = new FeatureLayer({
 });
 ```
 
-<img v-click="2" src="./renderers.avif">
+<img v-click="2" src="/renderers.avif">
 
 ---
 layout: image-right


### PR DESCRIPTION
`./basemaps-list.avif` works in dev server, but it [fails build](https://github.com/maxpatiiuk/esri-dev-summit-presentations/actions/runs/22124132440/job/63950431155) as there is no `basemaps-list.avif` file relative to slides.md.

either use `./public/basempas-list.avif` or `/basemaps-list.avif`

-- fixed by claude. I thought it was the file extension issue