### PR TITLE
chore(2026): refine styling

### DIFF
--- a/2026/.meta/styles.css
+++ b/2026/.meta/styles.css
@@ -3,7 +3,10 @@
   color-scheme: only light;
 }
 
-#page-root {
+/** Style the slide container, without affecting Slidev controls */
+#slide-content,
+/* Style the slide preview in the slides gallery */
+.slidev-slide-container {
   /*
    * While code blocks are in light mode, the slide background is darker so
    * slide text defaults to white

--- a/2026/a-look-under-the-hood/setup/shiki.js
+++ b/2026/a-look-under-the-hood/setup/shiki.js
@@ -1,1 +1,0 @@
-export * from '../../.meta/shiki';

--- a/2026/a-look-under-the-hood/setup/shiki.ts
+++ b/2026/a-look-under-the-hood/setup/shiki.ts
@@ -1,0 +1,1 @@
+export { default } from '../../.meta/shiki';

--- a/2026/build-tooling/setup/shiki.js
+++ b/2026/build-tooling/setup/shiki.js
@@ -1,1 +1,0 @@
-export * from '../../.meta/shiki';

--- a/2026/build-tooling/setup/shiki.ts
+++ b/2026/build-tooling/setup/shiki.ts
@@ -1,0 +1,1 @@
+export { default } from '../../.meta/shiki';

--- a/2026/using-components-2/setup/shiki.js
+++ b/2026/using-components-2/setup/shiki.js
@@ -1,1 +1,0 @@
-export * from '../../.meta/shiki';

--- a/2026/using-components-2/setup/shiki.ts
+++ b/2026/using-components-2/setup/shiki.ts
@@ -1,0 +1,1 @@
+export { default } from '../../.meta/shiki';

--- a/2026/vis-techniques-3d/setup/shiki.js
+++ b/2026/vis-techniques-3d/setup/shiki.js
@@ -1,1 +1,0 @@
-export * from '../../.meta/shiki';

--- a/2026/vis-techniques-3d/setup/shiki.ts
+++ b/2026/vis-techniques-3d/setup/shiki.ts
@@ -1,0 +1,1 @@
+export { default } from '../../.meta/shiki';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,13 @@ import eslintConfigLumina from '@arcgis/eslint-config/lumina';
 
 export default [
   {
-    ignores: ['dist', 'node_modules', '**/*.js', '**/*.cjs'],
+    ignores: [
+      'dist',
+      'node_modules',
+      '**/*.js',
+      '**/*.cjs',
+      '**/setup/shiki.ts',
+    ],
   },
   ...eslintConfig,
   ...eslintConfigLumina,


### PR DESCRIPTION
Small styling refinement - fix slidev's controls being white on white

Fix `github-light` color scheme not getting applied (the default color scheme has insufficient contrast). Turns out Slidev looks for .ts files specifically, not .js.