### PR TITLE
refactor(2026-build-tooling): refresh slides

### DIFF
--- a/2025/build-tooling/README.md
+++ b/2025/build-tooling/README.md
@@ -25,7 +25,7 @@ Presented at [Esri Developer Summit 2025](https://devtechsummit2025.esri.com/).
 ### Vite ⚡
 
 - [Final demo app](./demo/final)
-- [Basic demo apo](./demo/1-javascript)
+- [Basic demo app](./demo/1-javascript)
   - Run `npm create vite` to create a new Vite project
 - [Documentation](https://vitejs.dev/)
   - [Publishing guide](https://vite.dev/guide/static-deploy)
@@ -51,16 +51,16 @@ Presented at [Esri Developer Summit 2025](https://devtechsummit2025.esri.com/).
 - [Demo app](./demo/final)
   - [Get started steps](./demo/3-web-components/README.md#key-changes-from-2-react)
 - [Documentation](https://developers.arcgis.com/javascript)
-- [Get started (for NPM)](https://developers.arcgis.com/javascript/latest/get-started-npm/)
+- [Get started (for NPM)](https://developers.arcgis.com/javascript/latest/get-started/#npm)
 - [Maps SDK Resources](https://github.com/Esri/jsapi-resources)
-- [React sample app](https://github.com/Esri/jsapi-resources/tree/main/component-samples/map-components/samples/react)
+- [React sample app](https://github.com/Esri/jsapi-resources/tree/main/component-samples/map-and-charts-components-react)
 
 ### TypeScript 🦾
 
 - [Demo app](./demo/4-typescript)
   - [Get started steps](./demo/4-typescript/README.md#key-changes-from-3-web-components)
 - [Documentation](https://www.typescriptlang.org)
-- [Guide to using ArcGIS Maps SDK for JavaScript with TypeScript](https://developers.arcgis.com/javascript/latest/guide/typescript-setup/)
+- [Guide to using ArcGIS Maps SDK for JavaScript with TypeScript](https://developers.arcgis.com/javascript/latest/get-started/#typescript)
 - VS Code extension:
   - [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
 

--- a/2025/build-tooling/README.md
+++ b/2025/build-tooling/README.md
@@ -1,5 +1,7 @@
 # ArcGIS Maps SDK for JavaScript: Fast Development and Build Tooling
 
+[Recording](https://mediaspace.esri.com/media/t/1_jeg4ahle/368599242)
+
 Learn how Esri's development teams are leveraging modern tools like Vite to
 build fast, dynamic Web GIS applications. With features such as lazy loading,
 client-side routing, hot module replacement, and lightning-fast builds, Vite

--- a/2026/build-tooling/README.md
+++ b/2026/build-tooling/README.md
@@ -25,7 +25,7 @@ Presented at [Esri Developer Summit 2026](https://devtechsummit2026.esri.com/).
 ### Vite ⚡
 
 - [Final demo app](./demo/final)
-- [Basic demo app](./demo/1-javascript)
+- [Basic demo apo](./demo/1-javascript)
   - Run `npm create vite` to create a new Vite project
 - [Documentation](https://vitejs.dev/)
   - [Publishing guide](https://vite.dev/guide/static-deploy)
@@ -51,16 +51,16 @@ Presented at [Esri Developer Summit 2026](https://devtechsummit2026.esri.com/).
 - [Demo app](./demo/final)
   - [Get started steps](./demo/3-web-components/README.md#key-changes-from-2-react)
 - [Documentation](https://developers.arcgis.com/javascript)
-- [Get started (for NPM)](https://developers.arcgis.com/javascript/latest/get-started-npm/)
+- [Get started (for NPM)](https://developers.arcgis.com/javascript/latest/get-started/#npm)
 - [Maps SDK Resources](https://github.com/Esri/jsapi-resources)
-- [React sample app](https://github.com/Esri/jsapi-resources/tree/main/component-samples/map-components/samples/react)
+- [React sample app](https://github.com/Esri/jsapi-resources/tree/main/component-samples/map-and-charts-components-react)
 
 ### TypeScript 🦾
 
 - [Demo app](./demo/4-typescript)
   - [Get started steps](./demo/4-typescript/README.md#key-changes-from-3-web-components)
 - [Documentation](https://www.typescriptlang.org)
-- [Guide to using ArcGIS Maps SDK for JavaScript with TypeScript](https://developers.arcgis.com/javascript/latest/guide/typescript-setup/)
+- [Guide to using ArcGIS Maps SDK for JavaScript with TypeScript](https://developers.arcgis.com/javascript/latest/get-started/#typescript)
 - VS Code extension:
   - [Pretty TypeScript Errors](https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors)
 

--- a/2026/build-tooling/demo/1-javascript/package.json
+++ b/2026/build-tooling/demo/1-javascript/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "vite": "^7.3.0"
+    "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/2-react/README.md
+++ b/2026/build-tooling/demo/2-react/README.md
@@ -10,7 +10,7 @@
   # Install the Vite React plugin:
   npm install -D @vitejs/plugin-react-swc
   ```
-- Add react plugin to [vite.config.ts](./vite.config.ts)
+- Add react plugin to [vite.config.js](./vite.config.js)
 - Rename .js files to .jsx
 - Render Splash screen using React in [src/main.jsx](./src/main.jsx)
 - Use JSX syntax in [src/Splash.jsx](./src/Splash.jsx)

--- a/2026/build-tooling/demo/2-react/package.json
+++ b/2026/build-tooling/demo/2-react/package.json
@@ -9,11 +9,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-swc": "^4.2.2",
-    "vite": "^7.3.0"
+    "@vitejs/plugin-react-swc": "^4.2.3",
+    "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/3-web-components/package.json
+++ b/2026/build-tooling/demo/3-web-components/package.json
@@ -9,13 +9,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0-next.99",
-    "@esri/calcite-components": "^5.0.0-next.38",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "@arcgis/map-components": "^5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-swc": "^4.2.2",
-    "vite": "^7.3.0"
+    "@vitejs/plugin-react-swc": "^4.2.3",
+    "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/4-typescript/package.json
+++ b/2026/build-tooling/demo/4-typescript/package.json
@@ -9,16 +9,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "~4.32.9",
-    "@esri/calcite-components": "^3.0.3",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "@arcgis/map-components": "~5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@types/react": "^19.0.10",
-    "@types/react-dom": "^19.0.4",
-    "@vitejs/plugin-react-swc": "^3.8.0",
-    "typescript": "^5.8.2",
-    "vite": "^6.1.0"
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react-swc": "^4.2.3",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/5-eslint/package.json
+++ b/2026/build-tooling/demo/5-eslint/package.json
@@ -9,22 +9,22 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0-next.99",
-    "@esri/calcite-components": "^5.0.0-next.38",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "@arcgis/map-components": "^5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
-    "@types/react": "^19.2.7",
+    "@eslint/js": "^9.39.3",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.2",
+    "@vitejs/plugin-react-swc": "^4.2.3",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.4.26",
-    "globals": "^16.5.0",
+    "eslint-plugin-react-refresh": "^0.5.0",
+    "globals": "^17.3.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.50.1",
-    "vite": "^7.3.0"
+    "typescript-eslint": "^8.56.0",
+    "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/6-routes/README.md
+++ b/2026/build-tooling/demo/6-routes/README.md
@@ -41,6 +41,6 @@ For production build and deployment, see [Vite documentation](https://vite.dev/g
 
 1. Use Vite starter app (React + TypeScript): `npm init vite`
 
-2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started-npm/) guide to install `@arcgis/map-components`
+2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started/#npm) guide to install `@arcgis/map-components`
 
 3. Add `<calcite-shell>` and `<arcgis-map>` components to `App.tsx`

--- a/2026/build-tooling/demo/6-routes/package.json
+++ b/2026/build-tooling/demo/6-routes/package.json
@@ -13,24 +13,24 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0-next.99",
-    "@esri/calcite-components": "^5.0.0-next.38",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-router": "^7.11.0"
+    "@arcgis/map-components": "^5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
-    "@types/react": "^19.2.7",
+    "@eslint/js": "^9.39.3",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.2",
+    "@vitejs/plugin-react-swc": "^4.2.3",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.4.26",
-    "globals": "^16.5.0",
-    "prettier": "^3.7.4",
+    "eslint-plugin-react-refresh": "^0.5.0",
+    "globals": "^17.3.0",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.50.1",
-    "vite": "^7.3.0"
+    "typescript-eslint": "^8.56.0",
+    "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/7-testing/README.md
+++ b/2026/build-tooling/demo/7-testing/README.md
@@ -29,7 +29,7 @@
    npm install
    ```
 
-3. Copy `.env.local.example` to `.env.local` and update it with an [API key](https://developers.arcgis.com/documentation/security-and-authentication/api-key-authentication/tutorials/create-an-api-key/) that has access to the [ArcGIS Places service](https://developers.arcgis.com/rest/places/). Note, if you do not have an ArcGIS Location Platform account, sign up for free [here](https://location.arcgis.com/sign-up/).
+3. Copy `.env.local.example` to `.env.local` and update it with an [API key](https://developers.arcgis.com/documentation/security-and-authentication/api-key-authentication/tutorials/create-an-api-key/online/) that has access to the [ArcGIS Places service](https://developers.arcgis.com/rest/places/). Note, if you do not have an ArcGIS Location Platform account, sign up for free [here](https://location.arcgis.com/sign-up/).
 
 4. Start the development server
 
@@ -57,6 +57,6 @@ For production build and deployment, see [Vite documentation](https://vite.dev/g
 
 1. Use Vite starter app (React + TypeScript): `npm init vite`
 
-2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started-npm/) guide to install `@arcgis/map-components`
+2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started/#npm) guide to install `@arcgis/map-components`
 
 3. Add `<calcite-shell>` and `<arcgis-map>` components to `App.tsx`

--- a/2026/build-tooling/demo/7-testing/package.json
+++ b/2026/build-tooling/demo/7-testing/package.json
@@ -13,31 +13,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0-next.99",
-    "@esri/calcite-components": "^5.0.0-next.38",
-    "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-router": "^7.11.0"
+    "@arcgis/map-components": "^5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "@esri/arcgis-rest-places": "^4.9.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
+    "@eslint/js": "^9.39.3",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.1",
-    "@types/react": "^19.2.7",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.2",
-    "@vitest/browser": "^4.0.16",
+    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitest/browser": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.4.26",
-    "globals": "^16.5.0",
-    "msw": "^2.12.4",
-    "playwright": "^1.57.0",
-    "prettier": "^3.7.4",
+    "eslint-plugin-react-refresh": "^0.5.0",
+    "globals": "^17.3.0",
+    "msw": "^2.12.10",
+    "playwright": "^1.58.2",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.50.1",
-    "vite": "^7.3.0",
-    "vitest": "^4.0.16"
+    "typescript-eslint": "^8.56.0",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/2026/build-tooling/demo/8-plugins/README.md
+++ b/2026/build-tooling/demo/8-plugins/README.md
@@ -29,7 +29,7 @@
    npm install
    ```
 
-3. Copy `.env.local.example` to `.env.local` and update it with an [API key](https://developers.arcgis.com/documentation/security-and-authentication/api-key-authentication/tutorials/create-an-api-key/) that has access to the [ArcGIS Places service](https://developers.arcgis.com/rest/places/). Note, if you do not have an ArcGIS Location Platform account, sign up for free [here](https://location.arcgis.com/sign-up/).
+3. Copy `.env.local.example` to `.env.local` and update it with an [API key](https://developers.arcgis.com/documentation/security-and-authentication/api-key-authentication/tutorials/create-an-api-key/online/) that has access to the [ArcGIS Places service](https://developers.arcgis.com/rest/places/). Note, if you do not have an ArcGIS Location Platform account, sign up for free [here](https://location.arcgis.com/sign-up/).
 
 4. Start the development server
 
@@ -57,6 +57,6 @@ For production build and deployment, see [Vite documentation](https://vite.dev/g
 
 1. Use Vite starter app (React + TypeScript): `npm init vite`
 
-2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started-npm/) guide to install `@arcgis/map-components`
+2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started/#npm) guide to install `@arcgis/map-components`
 
 3. Add `<calcite-shell>` and `<arcgis-map>` components to `App.tsx`

--- a/2026/build-tooling/demo/8-plugins/package.json
+++ b/2026/build-tooling/demo/8-plugins/package.json
@@ -13,31 +13,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0-next.99",
-    "@esri/calcite-components": "^5.0.0-next.38",
-    "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-router": "^7.11.0"
+    "@arcgis/map-components": "^5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "@esri/arcgis-rest-places": "^4.9.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
+    "@eslint/js": "^9.39.3",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.1",
-    "@types/react": "^19.2.7",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.2",
-    "@vitest/browser": "^4.0.16",
+    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitest/browser": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.4.26",
-    "globals": "^16.5.0",
-    "msw": "^2.12.4",
-    "playwright": "^1.57.0",
-    "prettier": "^3.7.4",
+    "eslint-plugin-react-refresh": "^0.5.0",
+    "globals": "^17.3.0",
+    "msw": "^2.12.10",
+    "playwright": "^1.58.2",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.50.1",
-    "vite": "^7.3.0",
-    "vitest": "^4.0.16"
+    "typescript-eslint": "^8.56.0",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/2026/build-tooling/demo/final/README.md
+++ b/2026/build-tooling/demo/final/README.md
@@ -29,7 +29,7 @@
    npm install
    ```
 
-3. Copy `.env.local.example` to `.env.local` and update it with an [API key](https://developers.arcgis.com/documentation/security-and-authentication/api-key-authentication/tutorials/create-an-api-key/) that has access to the [ArcGIS Places service](https://developers.arcgis.com/rest/places/). Note, if you do not have an ArcGIS Location Platform account, sign up for free [here](https://location.arcgis.com/sign-up/).
+3. Copy `.env.local.example` to `.env.local` and update it with an [API key](https://developers.arcgis.com/documentation/security-and-authentication/api-key-authentication/tutorials/create-an-api-key/online/) that has access to the [ArcGIS Places service](https://developers.arcgis.com/rest/places/). Note, if you do not have an ArcGIS Location Platform account, sign up for free [here](https://location.arcgis.com/sign-up/).
 
 4. Start the development server
 
@@ -57,6 +57,6 @@ For production build and deployment, see [Vite documentation](https://vite.dev/g
 
 1. Use Vite starter app (React + TypeScript): `npm init vite`
 
-2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started-npm/) guide to install `@arcgis/map-components`
+2. Follow the Maps SDK's ["Get started with npm"](https://developers.arcgis.com/javascript/latest/get-started/#npm) guide to install `@arcgis/map-components`
 
 3. Add `<calcite-shell>` and `<arcgis-map>` components to `App.tsx`

--- a/2026/build-tooling/demo/final/package.json
+++ b/2026/build-tooling/demo/final/package.json
@@ -13,31 +13,31 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0-next.99",
-    "@esri/calcite-components": "^5.0.0-next.38",
-    "@esri/arcgis-rest-places": "^1.2.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "react-router": "^7.11.0"
+    "@arcgis/map-components": "^5.0.0",
+    "@esri/calcite-components": "^5.0.2",
+    "@esri/arcgis-rest-places": "^4.9.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.2",
+    "@eslint/js": "^9.39.3",
     "@testing-library/dom": "^10.4.1",
-    "@testing-library/react": "^16.3.1",
-    "@types/react": "^19.2.7",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.2",
-    "@vitest/browser": "^4.0.16",
+    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitest/browser": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.4.26",
-    "globals": "^16.5.0",
-    "msw": "^2.12.4",
-    "playwright": "^1.57.0",
-    "prettier": "^3.7.4",
+    "eslint-plugin-react-refresh": "^0.5.0",
+    "globals": "^17.3.0",
+    "msw": "^2.12.10",
+    "playwright": "^1.58.2",
+    "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.50.1",
-    "vite": "^7.3.0",
-    "vitest": "^4.0.16"
+    "typescript-eslint": "^8.56.0",
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
Update dependencies

Update outdated links

@hcampos-professional the 6-routes and the following demos have TypeScript errors due to api changes. Let me know if you are going to use different demo apps or refresh existing demo apps