### PR TITLE
chore: update build tooling demos

### DIFF
--- a/2026/build-tooling/demo/1-javascript/README.md
+++ b/2026/build-tooling/demo/1-javascript/README.md
@@ -2,7 +2,7 @@
 
 [Session Description](../..)
 
-## Technologies used
+## Technologies used:
 
 - [Vite](https://vite.dev/)
 

--- a/2026/build-tooling/demo/1-javascript/README.md
+++ b/2026/build-tooling/demo/1-javascript/README.md
@@ -2,9 +2,9 @@
 
 [Session Description](../..)
 
-## Technologies used:
+## Technologies used
 
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 
 ## Installation
 

--- a/2026/build-tooling/demo/1-javascript/vite.config.js
+++ b/2026/build-tooling/demo/1-javascript/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,

--- a/2026/build-tooling/demo/2-react/README.md
+++ b/2026/build-tooling/demo/2-react/README.md
@@ -17,7 +17,7 @@
 
 ## Technologies used:
 
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [React](https://react.dev/)
 
 ## Installation

--- a/2026/build-tooling/demo/2-react/vite.config.js
+++ b/2026/build-tooling/demo/2-react/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 // Import the react plugin
 import react from "@vitejs/plugin-react-swc";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,

--- a/2026/build-tooling/demo/3-web-components/README.md
+++ b/2026/build-tooling/demo/3-web-components/README.md
@@ -17,7 +17,7 @@ Based on [Calcite get started](https://developers.arcgis.com/calcite-design-syst
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [React](https://react.dev/)
 
 ## Installation

--- a/2026/build-tooling/demo/3-web-components/vite.config.js
+++ b/2026/build-tooling/demo/3-web-components/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 // Import the react plugin
 import react from "@vitejs/plugin-react-swc";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,

--- a/2026/build-tooling/demo/4-typescript/README.md
+++ b/2026/build-tooling/demo/4-typescript/README.md
@@ -37,7 +37,7 @@ Tips:
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [React](https://react.dev/)
 

--- a/2026/build-tooling/demo/4-typescript/vite.config.ts
+++ b/2026/build-tooling/demo/4-typescript/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 // Import the react plugin
 import react from "@vitejs/plugin-react-swc";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,

--- a/2026/build-tooling/demo/5-eslint/README.md
+++ b/2026/build-tooling/demo/5-eslint/README.md
@@ -34,7 +34,7 @@ Tip:
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [React](https://react.dev/)
 - [ESLint](https://eslint.org/)

--- a/2026/build-tooling/demo/5-eslint/vite.config.ts
+++ b/2026/build-tooling/demo/5-eslint/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 // Import the react plugin
 import react from "@vitejs/plugin-react-swc";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,

--- a/2026/build-tooling/demo/6-routes/README.md
+++ b/2026/build-tooling/demo/6-routes/README.md
@@ -2,7 +2,7 @@
 
 [Session Description](../..)
 
-## Technologies used
+## Technologies used:
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)

--- a/2026/build-tooling/demo/6-routes/README.md
+++ b/2026/build-tooling/demo/6-routes/README.md
@@ -2,11 +2,11 @@
 
 [Session Description](../..)
 
-## Technologies used:
+## Technologies used
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [ESLint](https://eslint.org/)
 - [React](https://react.dev/)

--- a/2026/build-tooling/demo/6-routes/package.json
+++ b/2026/build-tooling/demo/6-routes/package.json
@@ -13,25 +13,26 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "5.0.0",
-    "@arcgis/map-components": "5.0.0",
+    "@arcgis/core": "^5.0.2",
+    "@arcgis/map-components": "^5.0.2",
     "@esri/calcite-components": "^5.0.2",
+    "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "^7.13.0"
+    "react-router": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.5.0",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.3.0",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "^8.56.1",
     "vite": "^7.3.1"
   }
 }

--- a/2026/build-tooling/demo/6-routes/package.json
+++ b/2026/build-tooling/demo/6-routes/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0",
+    "@arcgis/core": "5.0.0",
+    "@arcgis/map-components": "5.0.0",
     "@esri/calcite-components": "^5.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/2026/build-tooling/demo/6-routes/src/App.tsx
+++ b/2026/build-tooling/demo/6-routes/src/App.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef } from "react";
-import "@esri/calcite-components/components/calcite-shell";
-import "@esri/calcite-components/components/calcite-shell-panel";
 import "@arcgis/map-components/components/arcgis-features";
 import "@arcgis/map-components/components/arcgis-legend";
 import "@arcgis/map-components/components/arcgis-map";
+import "@esri/calcite-components/components/calcite-shell";
+import "@esri/calcite-components/components/calcite-shell-panel";
+import { useRef, useState } from "react";
 
 import type Graphic from "@arcgis/core/Graphic.js";
 
@@ -17,10 +17,13 @@ function App() {
   >();
 
   function onMapClick(event: HTMLArcgisMapElement["arcgisViewClick"]) {
-    featuresElement.current?.open({
-      location: event.detail.mapPoint,
-      fetchFeatures: true,
-    });
+    const { current } = featuresElement;
+    if (!current) {
+      return;
+    }
+
+    current.fetchFeatures(event.detail);
+    current.open = true;
   }
 
   function onFeaturesChange(
@@ -43,13 +46,15 @@ function App() {
           }
         >
           <div className="panel-content">
-            <arcgis-features
-              hideCloseButton
-              hideHeading
-              ref={featuresElement}
-              referenceElement={mapElement}
-              onarcgisPropertyChange={onFeaturesChange}
-            ></arcgis-features>
+            {mapElement ? (
+              <arcgis-features
+                hideCloseButton
+                hideHeading
+                ref={featuresElement}
+                referenceElement={mapElement}
+                onarcgisPropertyChange={onFeaturesChange}
+              />
+            ) : undefined}
           </div>
         </calcite-panel>
       </calcite-shell-panel>
@@ -60,7 +65,7 @@ function App() {
         onarcgisViewClick={onMapClick}
       >
         <arcgis-legend
-          position="bottom-right"
+          slot="bottom-right"
           legend-style="classic"
         ></arcgis-legend>
       </arcgis-map>

--- a/2026/build-tooling/demo/6-routes/vite.config.ts
+++ b/2026/build-tooling/demo/6-routes/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/2026/build-tooling/demo/6-routes/vite.config.ts
+++ b/2026/build-tooling/demo/6-routes/vite.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,

--- a/2026/build-tooling/demo/7-testing/README.md
+++ b/2026/build-tooling/demo/7-testing/README.md
@@ -6,7 +6,7 @@
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [ESLint](https://eslint.org/)
 - [React](https://react.dev/)

--- a/2026/build-tooling/demo/7-testing/package.json
+++ b/2026/build-tooling/demo/7-testing/package.json
@@ -28,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.3",
     "@vitest/browser": "^4.0.18",
+    "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.0",

--- a/2026/build-tooling/demo/7-testing/package.json
+++ b/2026/build-tooling/demo/7-testing/package.json
@@ -13,13 +13,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "5.0.0",
-    "@arcgis/map-components": "5.0.0",
+    "@arcgis/core": "^5.0.2",
+    "@arcgis/map-components": "^5.0.2",
     "@esri/calcite-components": "^5.0.2",
     "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "^7.13.0"
+    "react-router": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
@@ -27,18 +27,18 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.5.0",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.3.0",
     "msw": "^2.12.10",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "^8.56.1",
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
   }

--- a/2026/build-tooling/demo/7-testing/package.json
+++ b/2026/build-tooling/demo/7-testing/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0",
+    "@arcgis/core": "5.0.0",
+    "@arcgis/map-components": "5.0.0",
     "@esri/calcite-components": "^5.0.2",
     "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",

--- a/2026/build-tooling/demo/7-testing/src/App.tsx
+++ b/2026/build-tooling/demo/7-testing/src/App.tsx
@@ -3,6 +3,7 @@ import Point from "@arcgis/core/geometry/Point.js";
 import type Polygon from "@arcgis/core/geometry/Polygon";
 import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
 import Graphic from "@arcgis/core/Graphic.js";
+import ActionButton from "@arcgis/core/support/actions/ActionButton.js";
 import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
 import type { PopupAction } from "@arcgis/core/widgets/Popup/types";
 import "@arcgis/map-components/components/arcgis-features";
@@ -18,7 +19,6 @@ import "@esri/calcite-components/components/calcite-shell";
 import "@esri/calcite-components/components/calcite-shell-panel";
 import { useRef, useState } from "react";
 import type { Result, ServiceInfo } from "./interfaces";
-import ActionButton from "@arcgis/core/support/actions/ActionButton.js";
 
 const featureActions = new Collection<PopupAction>([
   new ActionButton({

--- a/2026/build-tooling/demo/7-testing/src/App.tsx
+++ b/2026/build-tooling/demo/7-testing/src/App.tsx
@@ -1,31 +1,31 @@
-import { useState, useRef } from "react";
+import Collection from "@arcgis/core/core/Collection.js";
+import Point from "@arcgis/core/geometry/Point.js";
+import type Polygon from "@arcgis/core/geometry/Polygon";
+import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
+import Graphic from "@arcgis/core/Graphic.js";
+import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
+import type { PopupAction } from "@arcgis/core/widgets/Popup/types";
+import "@arcgis/map-components/components/arcgis-features";
+import "@arcgis/map-components/components/arcgis-legend";
+import "@arcgis/map-components/components/arcgis-map";
+import { findPlacesNearPoint } from "@esri/arcgis-rest-places";
 import "@esri/calcite-components/components/calcite-alert";
-import "@esri/calcite-components/components/calcite-shell";
-import "@esri/calcite-components/components/calcite-shell-panel";
 import "@esri/calcite-components/components/calcite-list";
 import "@esri/calcite-components/components/calcite-list-item";
 import "@esri/calcite-components/components/calcite-list-item-group";
 import "@esri/calcite-components/components/calcite-progress";
-import "@arcgis/map-components/components/arcgis-features";
-import "@arcgis/map-components/components/arcgis-legend";
-import "@arcgis/map-components/components/arcgis-map";
-
-import type Polygon from "@arcgis/core/geometry/Polygon";
-import Graphic from "@arcgis/core/Graphic.js";
-import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
-import Point from "@arcgis/core/geometry/Point.js";
-import Collection from "@arcgis/core/core/Collection.js";
-import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
-import { findPlacesNearPoint } from "@esri/arcgis-rest-places";
-
+import "@esri/calcite-components/components/calcite-shell";
+import "@esri/calcite-components/components/calcite-shell-panel";
+import { useRef, useState } from "react";
 import type { Result, ServiceInfo } from "./interfaces";
+import ActionButton from "@arcgis/core/support/actions/ActionButton.js";
 
-const featureActions = new Collection([
-  {
+const featureActions = new Collection<PopupAction>([
+  new ActionButton({
     title: "Load nearby schools",
     id: "load-schools",
     icon: "education",
-  },
+  }),
 ]);
 
 const schoolSymbol = new WebStyleSymbol({
@@ -45,10 +45,13 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
     useState<Result<Collection<Graphic>>>();
 
   function onMapClick(event: HTMLArcgisMapElement["arcgisViewClick"]) {
-    featuresElement.current?.open({
-      location: event.detail.mapPoint,
-      fetchFeatures: true,
-    });
+    const { current } = featuresElement;
+    if (!current) {
+      return;
+    }
+
+    current.fetchFeatures(event.detail);
+    current.open = true;
   }
 
   function onFeaturesChange(
@@ -115,21 +118,20 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
           }
         >
           {schoolResults?.loading && (
-            <calcite-progress
-              type="indeterminate"
-              className="sticky-top"
-            ></calcite-progress>
+            <calcite-progress type="indeterminate" className="sticky-top" />
           )}
           <div className="panel-content">
-            <arcgis-features
-              hideCloseButton
-              hideHeading
-              ref={featuresElement}
-              referenceElement={mapElement}
-              actions={featureActions}
-              onarcgisPropertyChange={onFeaturesChange}
-              onarcgisTriggerAction={onFeatureActionClicked}
-            ></arcgis-features>
+            {mapElement ? (
+              <arcgis-features
+                hideCloseButton
+                hideHeading
+                ref={featuresElement}
+                referenceElement={mapElement}
+                actions={featureActions}
+                onarcgisPropertyChange={onFeaturesChange}
+                onarcgisTriggerAction={onFeatureActionClicked}
+              />
+            ) : undefined}
             {schoolResults?.result && (
               <calcite-list label="Nearby schools">
                 <calcite-list-item-group heading="Nearby schools">
@@ -154,10 +156,7 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
         ref={setMapElement}
         onarcgisViewClick={onMapClick}
       >
-        <arcgis-legend
-          position="bottom-right"
-          legend-style="classic"
-        ></arcgis-legend>
+        <arcgis-legend slot="bottom-right" legend-style="classic" />
       </arcgis-map>
       {schoolResults?.error && (
         <calcite-alert

--- a/2026/build-tooling/demo/7-testing/src/tests/App.test.tsx
+++ b/2026/build-tooling/demo/7-testing/src/tests/App.test.tsx
@@ -1,9 +1,9 @@
-import { render, fireEvent } from "@testing-library/react";
+import { cleanup, render, fireEvent } from "@testing-library/react";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { setupWorker } from "msw/browser";
 import { http, HttpResponse, passthrough } from "msw";
-import { beforeEach, it as itBase, expect, vi } from "vitest";
-import Point from "@arcgis/core/geometry/Point";
+import { beforeEach, afterEach, it as itBase, expect, assert } from "vitest";
+import { page } from "vitest/browser";
 import nearbySchoolsStub from "../__mock_data__/nearby-schools.json";
 import App from "../App";
 
@@ -26,7 +26,6 @@ const worker = setupWorker(
 
 const it = itBase.extend({
   worker: [
-    // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       // Start the worker before the test.
       await worker.start({ quiet: true });
@@ -51,9 +50,13 @@ let results: ReturnType<typeof render>;
 beforeEach(async () => {
   results = render(<App placesServiceInfo={placesServiceInfo} />);
   map = results.container.querySelector("arcgis-map")!;
-  await vi.waitFor(() => expect(map.updating).toEqual(false), {
-    timeout: 15000,
-  });
+  await expect.poll(() => map.updating, { timeout: 150000 }).toBeFalsy();
+});
+
+afterEach(() => {
+  // Prevent state leakage across tests from both DOM and MSW handlers.
+  cleanup();
+  worker.resetHandlers();
 });
 
 it("renders", () => {
@@ -65,56 +68,65 @@ it("renders", () => {
 
 it("shows a popup details when a feature is clicked", async () => {
   const { container } = results;
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
+  clickMapAt({ x: 500, y: 100 });
 
-  const popup = container.querySelector("arcgis-features")!;
-  const panel = container.querySelector("calcite-panel")!;
-  await vi.waitFor(() => {
-    expect(popup.features).toHaveLength(1);
-    expect(panel.description).toContain("Census tract");
-  });
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await expect
+    .poll(() => container.querySelector("calcite-panel")?.description)
+    .toContain("Census tract");
 });
 
 it("loads nearby schools for the selected feature", async () => {
   const { container } = results;
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
-  const popup = container.querySelector("arcgis-features")!;
-  await vi.waitFor(() => expect(popup.features).toHaveLength(1));
-  const action = container.querySelector<HTMLCalciteActionElement>(
-    "calcite-action[data-action-id=load-schools]",
-  );
-  action!.click();
+  clickMapAt({ x: 500, y: 100 });
 
-  await vi.waitFor(() =>
-    expect(container.querySelectorAll("calcite-list-item")).toHaveLength(1),
-  );
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await page.getByTitle("Load nearby schools").click();
+
+  await expect
+    .poll(() => container.querySelectorAll("calcite-list-item"))
+    .toHaveLength(1);
 });
 
 it("shows an error when loading schools fails", async () => {
   const { container } = results;
+
   worker.use(
     http.get(placesServiceInfo.endpoint, () =>
       HttpResponse.json({ error: "error" }, { status: 500 }),
     ),
   );
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
-  const popup = container.querySelector("arcgis-features")!;
-  await vi.waitFor(() => expect(popup.features).toHaveLength(1));
-  const action = container.querySelector<HTMLCalciteActionElement>(
-    "calcite-action[data-action-id=load-schools]",
-  );
-  action!.click();
+  clickMapAt({ x: 500, y: 100 });
 
-  await vi.waitFor(() =>
-    expect(container.querySelector("calcite-alert")).toBeInTheDocument(),
-  );
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await page.getByTitle("Load nearby schools").click();
+
+  await expect
+    .poll(() => container.querySelector("calcite-alert"))
+    .not.toBeNull();
 });
+
+function clickMapAt(point: { x: number; y: number }) {
+  const { x, y } = point;
+  const topLevelTarget = document.elementFromPoint(x, y);
+  const target =
+    topLevelTarget?.shadowRoot?.elementFromPoint(x, y) ?? topLevelTarget;
+
+  assert(target);
+
+  const options = { clientX: point.x, clientY: point.y };
+  fireEvent.pointerDown(target, options);
+  fireEvent.pointerUp(target, options);
+}

--- a/2026/build-tooling/demo/7-testing/vite.config.ts
+++ b/2026/build-tooling/demo/7-testing/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       provider: playwright(),
       // https://vitest.dev/config/browser/playwright
       instances: [{ browser: "chromium" }],
+      viewport: { width: 800, height: 600 },
     },
     onConsoleLog: (msg) => {
       const ignores = [/^Lit is in dev mode/u, /^Using Calcite Components/u];

--- a/2026/build-tooling/demo/7-testing/vite.config.ts
+++ b/2026/build-tooling/demo/7-testing/vite.config.ts
@@ -1,8 +1,9 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,
@@ -18,8 +19,8 @@ export default defineConfig({
     setupFiles: "./src/setupTests.ts",
     browser: {
       enabled: true,
-      provider: "playwright",
-      // https://vitest.dev/guide/browser/playwright
+      provider: playwright(),
+      // https://vitest.dev/config/browser/playwright
       instances: [{ browser: "chromium" }],
     },
     onConsoleLog: (msg) => {

--- a/2026/build-tooling/demo/7-testing/vite.config.ts
+++ b/2026/build-tooling/demo/7-testing/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 

--- a/2026/build-tooling/demo/8-plugins/README.md
+++ b/2026/build-tooling/demo/8-plugins/README.md
@@ -6,7 +6,7 @@
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [ESLint](https://eslint.org/)
 - [React](https://react.dev/)

--- a/2026/build-tooling/demo/8-plugins/package.json
+++ b/2026/build-tooling/demo/8-plugins/package.json
@@ -28,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.3",
     "@vitest/browser": "^4.0.18",
+    "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.0",

--- a/2026/build-tooling/demo/8-plugins/package.json
+++ b/2026/build-tooling/demo/8-plugins/package.json
@@ -13,13 +13,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "5.0.0",
-    "@arcgis/map-components": "5.0.0",
+    "@arcgis/core": "^5.0.2",
+    "@arcgis/map-components": "^5.0.2",
     "@esri/calcite-components": "^5.0.2",
     "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "^7.13.0"
+    "react-router": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
@@ -27,18 +27,18 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.5.0",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.3.0",
     "msw": "^2.12.10",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "^8.56.1",
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
   }

--- a/2026/build-tooling/demo/8-plugins/package.json
+++ b/2026/build-tooling/demo/8-plugins/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0",
+    "@arcgis/core": "5.0.0",
+    "@arcgis/map-components": "5.0.0",
     "@esri/calcite-components": "^5.0.2",
     "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",

--- a/2026/build-tooling/demo/8-plugins/src/App.tsx
+++ b/2026/build-tooling/demo/8-plugins/src/App.tsx
@@ -1,31 +1,31 @@
-import { useState, useRef } from "react";
+import Collection from "@arcgis/core/core/Collection.js";
+import Point from "@arcgis/core/geometry/Point.js";
+import type Polygon from "@arcgis/core/geometry/Polygon";
+import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
+import Graphic from "@arcgis/core/Graphic.js";
+import ActionButton from "@arcgis/core/support/actions/ActionButton.js";
+import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
+import type { PopupAction } from "@arcgis/core/widgets/Popup/types";
+import "@arcgis/map-components/components/arcgis-features";
+import "@arcgis/map-components/components/arcgis-legend";
+import "@arcgis/map-components/components/arcgis-map";
+import { findPlacesNearPoint } from "@esri/arcgis-rest-places";
 import "@esri/calcite-components/components/calcite-alert";
-import "@esri/calcite-components/components/calcite-shell";
-import "@esri/calcite-components/components/calcite-shell-panel";
 import "@esri/calcite-components/components/calcite-list";
 import "@esri/calcite-components/components/calcite-list-item";
 import "@esri/calcite-components/components/calcite-list-item-group";
 import "@esri/calcite-components/components/calcite-progress";
-import "@arcgis/map-components/components/arcgis-features";
-import "@arcgis/map-components/components/arcgis-legend";
-import "@arcgis/map-components/components/arcgis-map";
-
-import type Polygon from "@arcgis/core/geometry/Polygon";
-import Graphic from "@arcgis/core/Graphic.js";
-import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
-import Point from "@arcgis/core/geometry/Point.js";
-import Collection from "@arcgis/core/core/Collection.js";
-import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
-import { findPlacesNearPoint } from "@esri/arcgis-rest-places";
-
+import "@esri/calcite-components/components/calcite-shell";
+import "@esri/calcite-components/components/calcite-shell-panel";
+import { useRef, useState } from "react";
 import type { Result, ServiceInfo } from "./interfaces";
 
-const featureActions = new Collection([
-  {
+const featureActions = new Collection<PopupAction>([
+  new ActionButton({
     title: "Load nearby schools",
     id: "load-schools",
     icon: "education",
-  },
+  }),
 ]);
 
 const schoolSymbol = new WebStyleSymbol({
@@ -46,10 +46,13 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
     useState<Result<Collection<Graphic>>>();
 
   function onMapClick(event: HTMLArcgisMapElement["arcgisViewClick"]) {
-    featuresElement.current?.open({
-      location: event.detail.mapPoint,
-      fetchFeatures: true,
-    });
+    const { current } = featuresElement;
+    if (!current) {
+      return;
+    }
+
+    current.fetchFeatures(event.detail);
+    current.open = true;
   }
 
   function onFeaturesChange(
@@ -124,21 +127,21 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
           }
         >
           {schoolResults?.loading && (
-            <calcite-progress
-              type="indeterminate"
-              className="sticky-top"
-            ></calcite-progress>
+            <calcite-progress type="indeterminate" className="sticky-top" />
           )}
           <div className="panel-content">
-            <arcgis-features
-              hideCloseButton
-              hideHeading
-              ref={featuresElement}
-              referenceElement={mapElement}
-              actions={featureActions}
-              onarcgisPropertyChange={onFeaturesChange}
-              onarcgisTriggerAction={onFeatureActionClicked}
-            ></arcgis-features>
+            {mapElement ? (
+              <arcgis-features
+                hideCloseButton
+                hideHeading
+                ref={featuresElement}
+                referenceElement={mapElement}
+                actions={featureActions}
+                onarcgisPropertyChange={onFeaturesChange}
+                onarcgisTriggerAction={onFeatureActionClicked}
+              />
+            ) : undefined}
+
             {schoolResults?.result && (
               <calcite-list label="Nearby schools">
                 <calcite-list-item-group heading="Nearby schools">
@@ -163,10 +166,7 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
         ref={setMapElement}
         onarcgisViewClick={onMapClick}
       >
-        <arcgis-legend
-          position="bottom-right"
-          legend-style="classic"
-        ></arcgis-legend>
+        <arcgis-legend slot="bottom-right" legend-style="classic" />
       </arcgis-map>
       {schoolResults?.error && (
         <calcite-alert

--- a/2026/build-tooling/demo/8-plugins/src/tests/App.test.tsx
+++ b/2026/build-tooling/demo/8-plugins/src/tests/App.test.tsx
@@ -1,9 +1,9 @@
-import { render, fireEvent } from "@testing-library/react";
+import { cleanup, render, fireEvent } from "@testing-library/react";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { setupWorker } from "msw/browser";
 import { http, HttpResponse, passthrough } from "msw";
-import { beforeEach, it as itBase, expect, vi } from "vitest";
-import Point from "@arcgis/core/geometry/Point";
+import { beforeEach, afterEach, it as itBase, expect, assert } from "vitest";
+import { page } from "vitest/browser";
 import nearbySchoolsStub from "../__mock_data__/nearby-schools.json";
 import App from "../App";
 
@@ -26,7 +26,6 @@ const worker = setupWorker(
 
 const it = itBase.extend({
   worker: [
-    // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       // Start the worker before the test.
       await worker.start({ quiet: true });
@@ -51,9 +50,13 @@ let results: ReturnType<typeof render>;
 beforeEach(async () => {
   results = render(<App placesServiceInfo={placesServiceInfo} />);
   map = results.container.querySelector("arcgis-map")!;
-  await vi.waitFor(() => expect(map.updating).toEqual(false), {
-    timeout: 15000,
-  });
+  await expect.poll(() => map.updating, { timeout: 150000 }).toBeFalsy();
+});
+
+afterEach(() => {
+  // Prevent state leakage across tests from both DOM and MSW handlers.
+  cleanup();
+  worker.resetHandlers();
 });
 
 it("renders", () => {
@@ -65,56 +68,65 @@ it("renders", () => {
 
 it("shows a popup details when a feature is clicked", async () => {
   const { container } = results;
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
+  clickMapAt({ x: 500, y: 100 });
 
-  const popup = container.querySelector("arcgis-features")!;
-  const panel = container.querySelector("calcite-panel")!;
-  await vi.waitFor(() => {
-    expect(popup.features).toHaveLength(1);
-    expect(panel.description).toContain("Census tract");
-  });
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await expect
+    .poll(() => container.querySelector("calcite-panel")?.description)
+    .toContain("Census tract");
 });
 
 it("loads nearby schools for the selected feature", async () => {
   const { container } = results;
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
-  const popup = container.querySelector("arcgis-features")!;
-  await vi.waitFor(() => expect(popup.features).toHaveLength(1));
-  const action = container.querySelector<HTMLCalciteActionElement>(
-    "calcite-action[data-action-id=load-schools]",
-  );
-  action!.click();
+  clickMapAt({ x: 500, y: 100 });
 
-  await vi.waitFor(() =>
-    expect(container.querySelectorAll("calcite-list-item")).toHaveLength(1),
-  );
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await page.getByTitle("Load nearby schools").click();
+
+  await expect
+    .poll(() => container.querySelectorAll("calcite-list-item"))
+    .toHaveLength(1);
 });
 
 it("shows an error when loading schools fails", async () => {
   const { container } = results;
+
   worker.use(
     http.get(placesServiceInfo.endpoint, () =>
       HttpResponse.json({ error: "error" }, { status: 500 }),
     ),
   );
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
-  const popup = container.querySelector("arcgis-features")!;
-  await vi.waitFor(() => expect(popup.features).toHaveLength(1));
-  const action = container.querySelector<HTMLCalciteActionElement>(
-    "calcite-action[data-action-id=load-schools]",
-  );
-  action!.click();
+  clickMapAt({ x: 500, y: 100 });
 
-  await vi.waitFor(() =>
-    expect(container.querySelector("calcite-alert")).toBeInTheDocument(),
-  );
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await page.getByTitle("Load nearby schools").click();
+
+  await expect
+    .poll(() => container.querySelector("calcite-alert"))
+    .not.toBeNull();
 });
+
+function clickMapAt(point: { x: number; y: number }) {
+  const { x, y } = point;
+  const topLevelTarget = document.elementFromPoint(x, y);
+  const target =
+    topLevelTarget?.shadowRoot?.elementFromPoint(x, y) ?? topLevelTarget;
+
+  assert(target);
+
+  const options = { clientX: point.x, clientY: point.y };
+  fireEvent.pointerDown(target, options);
+  fireEvent.pointerUp(target, options);
+}

--- a/2026/build-tooling/demo/8-plugins/vite.config.ts
+++ b/2026/build-tooling/demo/8-plugins/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       provider: playwright(),
       // https://vitest.dev/config/browser/playwright
       instances: [{ browser: "chromium" }],
+      viewport: { width: 800, height: 600 },
     },
     onConsoleLog: (msg) => {
       const ignores = [/^Lit is in dev mode/u, /^Using Calcite Components/u];

--- a/2026/build-tooling/demo/8-plugins/vite.config.ts
+++ b/2026/build-tooling/demo/8-plugins/vite.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
 import chaosMonkey from "./support/chaosMonkey.js";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,
@@ -32,8 +33,8 @@ export default defineConfig({
     setupFiles: "./src/setupTests.ts",
     browser: {
       enabled: true,
-      provider: "playwright",
-      // https://vitest.dev/guide/browser/playwright
+      provider: playwright(),
+      // https://vitest.dev/config/browser/playwright
       instances: [{ browser: "chromium" }],
     },
     onConsoleLog: (msg) => {

--- a/2026/build-tooling/demo/8-plugins/vite.config.ts
+++ b/2026/build-tooling/demo/8-plugins/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "vitest/config";
 import chaosMonkey from "./support/chaosMonkey.js";

--- a/2026/build-tooling/demo/final/README.md
+++ b/2026/build-tooling/demo/final/README.md
@@ -6,7 +6,7 @@
 
 - [Calcite Design System](https://developers.arcgis.com/calcite-design-system/)
 - [ArcGIS Maps SDK for JavaScript's ES modules](https://developers.arcgis.com/javascript/latest/)
-- [Vite](https://vitejs.dev/)
+- [Vite](https://vite.dev/)
 - [TypeScript](https://www.typescriptlang.org/)
 - [ESLint](https://eslint.org/)
 - [React](https://react.dev/)

--- a/2026/build-tooling/demo/final/package.json
+++ b/2026/build-tooling/demo/final/package.json
@@ -28,6 +28,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.3",
     "@vitest/browser": "^4.0.18",
+    "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.0",

--- a/2026/build-tooling/demo/final/package.json
+++ b/2026/build-tooling/demo/final/package.json
@@ -13,13 +13,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "5.0.0",
-    "@arcgis/map-components": "5.0.0",
+    "@arcgis/core": "^5.0.2",
+    "@arcgis/map-components": "^5.0.2",
     "@esri/calcite-components": "^5.0.2",
     "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "^7.13.0"
+    "react-router": "^7.13.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.3",
@@ -27,7 +27,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react-swc": "^4.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
     "@vitest/browser": "^4.0.18",
     "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",

--- a/2026/build-tooling/demo/final/package.json
+++ b/2026/build-tooling/demo/final/package.json
@@ -13,7 +13,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/map-components": "^5.0.0",
+    "@arcgis/core": "5.0.0",
+    "@arcgis/map-components": "5.0.0",
     "@esri/calcite-components": "^5.0.2",
     "@esri/arcgis-rest-places": "^4.9.0",
     "react": "^19.2.4",

--- a/2026/build-tooling/demo/final/src/App.tsx
+++ b/2026/build-tooling/demo/final/src/App.tsx
@@ -1,31 +1,31 @@
-import { useState, useRef } from "react";
+import Collection from "@arcgis/core/core/Collection.js";
+import Point from "@arcgis/core/geometry/Point.js";
+import type Polygon from "@arcgis/core/geometry/Polygon";
+import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
+import Graphic from "@arcgis/core/Graphic.js";
+import ActionButton from "@arcgis/core/support/actions/ActionButton.js";
+import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
+import type { PopupAction } from "@arcgis/core/widgets/Popup/types";
+import "@arcgis/map-components/components/arcgis-features";
+import "@arcgis/map-components/components/arcgis-legend";
+import "@arcgis/map-components/components/arcgis-map";
+import { findPlacesNearPoint } from "@esri/arcgis-rest-places";
 import "@esri/calcite-components/components/calcite-alert";
-import "@esri/calcite-components/components/calcite-shell";
-import "@esri/calcite-components/components/calcite-shell-panel";
 import "@esri/calcite-components/components/calcite-list";
 import "@esri/calcite-components/components/calcite-list-item";
 import "@esri/calcite-components/components/calcite-list-item-group";
 import "@esri/calcite-components/components/calcite-progress";
-import "@arcgis/map-components/components/arcgis-features";
-import "@arcgis/map-components/components/arcgis-legend";
-import "@arcgis/map-components/components/arcgis-map";
-
-import type Polygon from "@arcgis/core/geometry/Polygon";
-import Graphic from "@arcgis/core/Graphic.js";
-import WebStyleSymbol from "@arcgis/core/symbols/WebStyleSymbol.js";
-import Point from "@arcgis/core/geometry/Point.js";
-import Collection from "@arcgis/core/core/Collection.js";
-import { webMercatorToGeographic } from "@arcgis/core/geometry/support/webMercatorUtils.js";
-import { findPlacesNearPoint } from "@esri/arcgis-rest-places";
-
+import "@esri/calcite-components/components/calcite-shell";
+import "@esri/calcite-components/components/calcite-shell-panel";
+import { useRef, useState } from "react";
 import type { Result, ServiceInfo } from "./interfaces";
 
-const featureActions = new Collection([
-  {
+const featureActions = new Collection<PopupAction>([
+  new ActionButton({
     title: "Load nearby schools",
     id: "load-schools",
     icon: "education",
-  },
+  }),
 ]);
 
 const schoolSymbol = new WebStyleSymbol({
@@ -46,10 +46,13 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
     useState<Result<Collection<Graphic>>>();
 
   function onMapClick(event: HTMLArcgisMapElement["arcgisViewClick"]) {
-    featuresElement.current?.open({
-      location: event.detail.mapPoint,
-      fetchFeatures: true,
-    });
+    const { current } = featuresElement;
+    if (!current) {
+      return;
+    }
+
+    current.fetchFeatures(event.detail);
+    current.open = true;
   }
 
   function onFeaturesChange(
@@ -128,21 +131,20 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
           }
         >
           {schoolResults?.loading && (
-            <calcite-progress
-              type="indeterminate"
-              className="sticky-top"
-            ></calcite-progress>
+            <calcite-progress type="indeterminate" className="sticky-top" />
           )}
           <div className="panel-content">
-            <arcgis-features
-              hideCloseButton
-              hideHeading
-              ref={featuresElement}
-              referenceElement={mapElement}
-              actions={featureActions}
-              onarcgisPropertyChange={onFeaturesChange}
-              onarcgisTriggerAction={onFeatureActionClicked}
-            ></arcgis-features>
+            {mapElement ? (
+              <arcgis-features
+                hideCloseButton
+                hideHeading
+                ref={featuresElement}
+                referenceElement={mapElement}
+                actions={featureActions}
+                onarcgisPropertyChange={onFeaturesChange}
+                onarcgisTriggerAction={onFeatureActionClicked}
+              />
+            ) : undefined}
             {schoolResults?.result && (
               <calcite-list label="Nearby schools">
                 <calcite-list-item-group heading="Nearby schools">
@@ -167,10 +169,7 @@ function App({ placesServiceInfo }: { placesServiceInfo: ServiceInfo }) {
         ref={setMapElement}
         onarcgisViewClick={onMapClick}
       >
-        <arcgis-legend
-          position="bottom-right"
-          legend-style="classic"
-        ></arcgis-legend>
+        <arcgis-legend slot="bottom-right" legend-style="classic" />
       </arcgis-map>
       {schoolResults?.error && (
         <calcite-alert

--- a/2026/build-tooling/demo/final/src/tests/App.test.tsx
+++ b/2026/build-tooling/demo/final/src/tests/App.test.tsx
@@ -1,9 +1,9 @@
-import { render, fireEvent } from "@testing-library/react";
+import { cleanup, render, fireEvent } from "@testing-library/react";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { setupWorker } from "msw/browser";
 import { http, HttpResponse, passthrough } from "msw";
-import { beforeEach, it as itBase, expect, vi } from "vitest";
-import Point from "@arcgis/core/geometry/Point";
+import { beforeEach, afterEach, it as itBase, expect, assert } from "vitest";
+import { page } from "vitest/browser";
 import nearbySchoolsStub from "../__mock_data__/nearby-schools.json";
 import App from "../App";
 
@@ -26,7 +26,6 @@ const worker = setupWorker(
 
 const it = itBase.extend({
   worker: [
-    // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       // Start the worker before the test.
       await worker.start({ quiet: true });
@@ -51,9 +50,13 @@ let results: ReturnType<typeof render>;
 beforeEach(async () => {
   results = render(<App placesServiceInfo={placesServiceInfo} />);
   map = results.container.querySelector("arcgis-map")!;
-  await vi.waitFor(() => expect(map.updating).toEqual(false), {
-    timeout: 15000,
-  });
+  await expect.poll(() => map.updating, { timeout: 150000 }).toBeFalsy();
+});
+
+afterEach(() => {
+  // Prevent state leakage across tests from both DOM and MSW handlers.
+  cleanup();
+  worker.resetHandlers();
 });
 
 it("renders", () => {
@@ -65,56 +68,65 @@ it("renders", () => {
 
 it("shows a popup details when a feature is clicked", async () => {
   const { container } = results;
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
+  clickMapAt({ x: 500, y: 100 });
 
-  const popup = container.querySelector("arcgis-features")!;
-  const panel = container.querySelector("calcite-panel")!;
-  await vi.waitFor(() => {
-    expect(popup.features).toHaveLength(1);
-    expect(panel.description).toContain("Census tract");
-  });
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await expect
+    .poll(() => container.querySelector("calcite-panel")?.description)
+    .toContain("Census tract");
 });
 
 it("loads nearby schools for the selected feature", async () => {
   const { container } = results;
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
-  const popup = container.querySelector("arcgis-features")!;
-  await vi.waitFor(() => expect(popup.features).toHaveLength(1));
-  const action = container.querySelector<HTMLCalciteActionElement>(
-    "calcite-action[data-action-id=load-schools]",
-  );
-  action!.click();
+  clickMapAt({ x: 500, y: 100 });
 
-  await vi.waitFor(() =>
-    expect(container.querySelectorAll("calcite-list-item")).toHaveLength(1),
-  );
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await page.getByTitle("Load nearby schools").click();
+
+  await expect
+    .poll(() => container.querySelectorAll("calcite-list-item"))
+    .toHaveLength(1);
 });
 
 it("shows an error when loading schools fails", async () => {
   const { container } = results;
+
   worker.use(
     http.get(placesServiceInfo.endpoint, () =>
       HttpResponse.json({ error: "error" }, { status: 500 }),
     ),
   );
-  const mapPoint = new Point({ latitude: 40.9384275, longitude: -73.735152 });
-  const event = new CustomEvent("arcgisViewClick", { detail: { mapPoint } });
 
-  fireEvent(map, event);
-  const popup = container.querySelector("arcgis-features")!;
-  await vi.waitFor(() => expect(popup.features).toHaveLength(1));
-  const action = container.querySelector<HTMLCalciteActionElement>(
-    "calcite-action[data-action-id=load-schools]",
-  );
-  action!.click();
+  clickMapAt({ x: 500, y: 100 });
 
-  await vi.waitFor(() =>
-    expect(container.querySelector("calcite-alert")).toBeInTheDocument(),
-  );
+  await expect
+    .poll(() => container.querySelector("arcgis-features")?.features)
+    .toHaveLength(2);
+
+  await page.getByTitle("Load nearby schools").click();
+
+  await expect
+    .poll(() => container.querySelector("calcite-alert"))
+    .not.toBeNull();
 });
+
+function clickMapAt(point: { x: number; y: number }) {
+  const { x, y } = point;
+  const topLevelTarget = document.elementFromPoint(x, y);
+  const target =
+    topLevelTarget?.shadowRoot?.elementFromPoint(x, y) ?? topLevelTarget;
+
+  assert(target);
+
+  const options = { clientX: point.x, clientY: point.y };
+  fireEvent.pointerDown(target, options);
+  fireEvent.pointerUp(target, options);
+}

--- a/2026/build-tooling/demo/final/vite.config.ts
+++ b/2026/build-tooling/demo/final/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       provider: playwright(),
       // https://vitest.dev/guide/browser/playwright
       instances: [{ browser: "chromium" }],
+      viewport: { width: 800, height: 600 },
     },
     onConsoleLog: (msg) => {
       const ignores = [/^Lit is in dev mode/u, /^Using Calcite Components/u];

--- a/2026/build-tooling/demo/final/vite.config.ts
+++ b/2026/build-tooling/demo/final/vite.config.ts
@@ -1,6 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import chaosMonkey from "./support/chaosMonkey.js";
 

--- a/2026/build-tooling/demo/final/vite.config.ts
+++ b/2026/build-tooling/demo/final/vite.config.ts
@@ -1,9 +1,10 @@
 /// <reference types="vitest" />
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
+import { playwright } from "@vitest/browser-playwright";
 import chaosMonkey from "./support/chaosMonkey.js";
 
-// https://vitejs.dev/config/
+// https://vite.dev/config/
 export default defineConfig({
   server: {
     open: true,
@@ -32,7 +33,7 @@ export default defineConfig({
     setupFiles: "./src/setupTests.ts",
     browser: {
       enabled: true,
-      provider: "playwright",
+      provider: playwright(),
       // https://vitest.dev/guide/browser/playwright
       instances: [{ browser: "chromium" }],
     },


### PR DESCRIPTION
Updates various demos of the 2026 `build-tooling` presentation:
- Fixed Vite and Vitest URLs. Vite is now at https://vite.dev/ and Vitest is at https://vite.dev/
- Fixed various type errors due to public API changes in v5 of the Maps SDK.
- Updated Vite/Vitest configs to use `@vitest/browser-playwright`, as per https://vitest.dev/config/browser/playwright.html#configuring-playwright.
- Updated tests:
   - Use semantic locators instead of `querySelector` wherever possible.
   - Use simulated pointer events on the view rather than faking `arcgisViewClick`.
   - Use `expect.poll` instead of `vi.waitFor` since it's more representative of the intent.
   - Added an `afterEach` to perform cleanup after each test.