### PR TITLE
fix(2026): ensure text to be white also when exporting

### DIFF
--- a/2026/.meta/styles.css
+++ b/2026/.meta/styles.css
@@ -3,8 +3,8 @@
   color-scheme: only light;
 }
 
-/** Style the slide container, without affecting Slidev controls */
-.slidev-slide-content {
+/** Style the slide container, without affecting Slidev controls and working across modes and pdf export */
+.slidev-page {
   /*
    * While code blocks are in light mode, the slide background is darker so
    * slide text defaults to white


### PR DESCRIPTION
Text on slides when exporting where using the light themes default color.