### PR TITLE
feat(vis-techniques-3d): add script to compress images to AVIF format

### DIFF
--- a/2026/vis-techniques-3d/package.json
+++ b/2026/vis-techniques-3d/package.json
@@ -1,8 +1,10 @@
 {
+  "type": "module",
   "scripts": {
     "build": "slidev build",
     "start": "slidev --open",
     "export": "slidev export",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "compress-images": "node ./scripts/compress-images.ts"
   }
 }

--- a/2026/vis-techniques-3d/scripts/compress-images.ts
+++ b/2026/vis-techniques-3d/scripts/compress-images.ts
@@ -9,15 +9,20 @@ const publicDir = path.resolve('public');
 // ImageMagick quality: 0-100 (higher = larger files)
 const quality = 60;
 
+// Source image formats to convert to AVIF.
+const sourceExtensions = new Set(['.png', '.jpg', '.jpeg', '.webp']);
+
 try {
-  const files = listPngs(publicDir);
+  const files = listSourceImages(publicDir);
   if (files.length === 0) {
-    console.log(`No .png files found in ${publicDir}`);
+    console.log(
+      `No source images found in ${publicDir} for extensions: ${Array.from(sourceExtensions).join(', ')}`,
+    );
     process.exit(0);
   }
 
   for (const inputPath of files) {
-    const outputPath = inputPath.replace(/\.png$/iu, '.avif');
+    const outputPath = `${inputPath.slice(0, -path.extname(inputPath).length)}.avif`;
     const result = spawnSync(
       'magick',
       [inputPath, '-quality', String(quality), outputPath],
@@ -32,20 +37,25 @@ try {
       process.exit(result.status ?? 1);
     }
 
-    console.log(`${inputPath} -> ${outputPath}`);
+    fs.unlinkSync(inputPath);
+
+    console.log(`${inputPath} -> ${outputPath} (deleted original)`);
   }
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exit(1);
 }
 
-function listPngs(dir: string): string[] {
+function listSourceImages(dir: string): string[] {
   const files: string[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      files.push(...listPngs(fullPath));
-    } else if (entry.isFile() && fullPath.toLowerCase().endsWith('.png')) {
+      files.push(...listSourceImages(fullPath));
+    } else if (
+      entry.isFile() &&
+      sourceExtensions.has(path.extname(fullPath).toLowerCase())
+    ) {
       files.push(fullPath);
     }
   }

--- a/2026/vis-techniques-3d/scripts/compress-images.ts
+++ b/2026/vis-techniques-3d/scripts/compress-images.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const publicDir = path.resolve('public');
+
+// ImageMagick quality: 0-100 (higher = larger files)
+const quality = 60;
+
+try {
+  const files = listPngs(publicDir);
+  if (files.length === 0) {
+    console.log(`No .png files found in ${publicDir}`);
+    process.exit(0);
+  }
+
+  for (const inputPath of files) {
+    const outputPath = inputPath.replace(/\.png$/iu, '.avif');
+    const result = spawnSync(
+      'magick',
+      [inputPath, '-quality', String(quality), outputPath],
+      { stdio: 'inherit' },
+    );
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (result.status !== 0) {
+      process.exit(result.status ?? 1);
+    }
+
+    console.log(`${inputPath} -> ${outputPath}`);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+function listPngs(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listPngs(fullPath));
+    } else if (entry.isFile() && fullPath.toLowerCase().endsWith('.png')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}

--- a/2026/vis-techniques-3d/scripts/tsconfig.json
+++ b/2026/vis-techniques-3d/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+// TypeScript configuration reference: https://www.typescriptlang.org/tsconfig
+{
+  "include": ["*.ts"],
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "erasableSyntaxOnly": true,
+    "target": "ES2024",
+    "types": ["node"],
+    "skipLibCheck": true
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@arcgis/eslint-config": "~5.0.0-next.99",
         "@maxpatiiuk/prettier-config": "^2.0.0",
+        "@types/node": "^22.19.3",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
         "playwright-chromium": "^1.57.0",
@@ -394,7 +395,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.5"
       },
@@ -1546,6 +1546,57 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nuxt/kit": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.1.tgz",
+      "integrity": "sha512-QORZRjcuTKgo++XP1Pc2c2gqwRydkaExrIRfRI9vFsPA3AzuHVn5Gfmbv1ic8y34e78mr5DMBvJlelUaeOuajg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "c12": "^3.3.3",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "errx": "^0.1.0",
+        "exsolve": "^1.0.8",
+        "ignore": "^7.0.5",
+        "jiti": "^2.6.1",
+        "klona": "^2.0.6",
+        "knitwork": "^1.3.0",
+        "mlly": "^1.8.0",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "pkg-types": "^2.3.0",
+        "rc9": "^3.0.0",
+        "scule": "^1.3.0",
+        "semver": "^7.7.4",
+        "tinyglobby": "^0.2.15",
+        "ufo": "^1.6.3",
+        "unctx": "^2.5.0",
+        "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@nuxt/kit/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@nuxt/kit/node_modules/rc9": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.0.tgz",
+      "integrity": "sha512-MGOue0VqscKWQ104udASX/3GYDcKyPI4j4F8gu/jHHzglpmy9a/anZK3PNe8ug6aZFl+9GxLtdhe3kVZuMaQbA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/@pdf-lib/standard-fonts": {
@@ -9204,9 +9255,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9750,9 +9801,9 @@
       "license": "MIT"
     },
     "node_modules/ufo": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz",
-      "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
     },
     "node_modules/unconfig": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@arcgis/eslint-config": "~5.0.0-next.99",
     "@maxpatiiuk/prettier-config": "^2.0.0",
+    "@types/node": "^22.19.3",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "playwright-chromium": "^1.57.0",


### PR DESCRIPTION
Add a simple script which uses `magick` to compress images from `png` to `avif`. This is quite useful when updating screenshots, for example, since they're usually stored as `png`.

Maybe this could also be useful more at the top level? Just wanted to keep it simple for now, though.