### PR TITLE
Build Tooling 2026 - various Improvements

### DIFF
--- a/2026/build-tooling/demo/6-routes/package.json
+++ b/2026/build-tooling/demo/6-routes/package.json
@@ -13,10 +13,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^5.0.2",
-    "@arcgis/map-components": "^5.0.2",
+    "@arcgis/core": "^5.0.9",
+    "@arcgis/map-components": "^5.0.9",
     "@esri/calcite-components": "^5.0.2",
-    "@esri/arcgis-rest-places": "^4.9.0",
+    "@esri/arcgis-rest-places": "^4.10.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.1"
@@ -29,7 +29,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "globals": "^17.3.0",
+    "globals": "^17.4.0",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.1",

--- a/2026/build-tooling/demo/6-routes/src/main.tsx
+++ b/2026/build-tooling/demo/6-routes/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";

--- a/2026/build-tooling/demo/7-sonda/package.json
+++ b/2026/build-tooling/demo/7-sonda/package.json
@@ -14,9 +14,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^5.0.2",
-    "@arcgis/map-components": "^5.0.2",
-    "@esri/arcgis-rest-places": "^4.9.0",
+    "@arcgis/core": "^5.0.9",
+    "@arcgis/map-components": "^5.0.9",
+    "@esri/arcgis-rest-places": "^4.10.0",
     "@esri/calcite-components": "^5.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -30,7 +30,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "globals": "^17.3.0",
+    "globals": "^17.4.0",
     "prettier": "^3.8.1",
     "sonda": "^0.11.1",
     "typescript": "^5.9.3",

--- a/2026/build-tooling/demo/7-sonda/src/main.tsx
+++ b/2026/build-tooling/demo/7-sonda/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";

--- a/2026/build-tooling/demo/8-testing/package.json
+++ b/2026/build-tooling/demo/8-testing/package.json
@@ -14,10 +14,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^5.0.2",
-    "@arcgis/map-components": "^5.0.2",
+    "@arcgis/core": "^5.0.9",
+    "@arcgis/map-components": "^5.0.9",
     "@esri/calcite-components": "^5.0.2",
-    "@esri/arcgis-rest-places": "^4.9.0",
+    "@esri/arcgis-rest-places": "^4.10.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.1"
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "globals": "^17.3.0",
+    "globals": "^17.4.0",
     "msw": "^2.12.10",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",

--- a/2026/build-tooling/demo/8-testing/src/interfaces.ts
+++ b/2026/build-tooling/demo/8-testing/src/interfaces.ts
@@ -7,6 +7,6 @@ export interface Result<T> {
 }
 
 export interface ServiceInfo {
-  authentication: ApiKeyManager;
+  authentication?: ApiKeyManager;
   endpoint?: string;
 }

--- a/2026/build-tooling/demo/8-testing/src/main.tsx
+++ b/2026/build-tooling/demo/8-testing/src/main.tsx
@@ -9,7 +9,14 @@ const App = React.lazy(async () => await import("./App"));
 const Splash = React.lazy(async () => await import("./Splash"));
 
 const placesServiceInfo = {
-  authentication: ApiKeyManager.fromKey(import.meta.env.VITE_API_KEY),
+  authentication: (() => {
+    try {
+      return ApiKeyManager.fromKey(import.meta.env.VITE_API_KEY);
+    } catch (error) {
+      console.warn("No API key provided, places service will not work", error);
+      return undefined;
+    }
+  })(),
   // Use a local proxy in development mode
   endpoint: import.meta.env.DEV
     ? "/arcgis/rest/services/places-service/v1/places/near-point"

--- a/2026/build-tooling/demo/8-testing/src/main.tsx
+++ b/2026/build-tooling/demo/8-testing/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";

--- a/2026/build-tooling/demo/8-testing/src/tests/App.test.tsx
+++ b/2026/build-tooling/demo/8-testing/src/tests/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, fireEvent } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { setupWorker } from "msw/browser";
 import { http, HttpResponse, passthrough } from "msw";
@@ -26,6 +26,7 @@ const worker = setupWorker(
 
 const it = itBase.extend({
   worker: [
+    // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       // Start the worker before the test.
       await worker.start({ quiet: true });
@@ -69,7 +70,7 @@ it("renders", () => {
 it("shows a popup details when a feature is clicked", async () => {
   const { container } = results;
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -83,7 +84,7 @@ it("shows a popup details when a feature is clicked", async () => {
 it("loads nearby schools for the selected feature", async () => {
   const { container } = results;
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -105,7 +106,7 @@ it("shows an error when loading schools fails", async () => {
     ),
   );
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -118,15 +119,13 @@ it("shows an error when loading schools fails", async () => {
     .not.toBeNull();
 });
 
-function clickMapAt(point: { x: number; y: number }) {
-  const { x, y } = point;
-  const topLevelTarget = document.elementFromPoint(x, y);
-  const target =
-    topLevelTarget?.shadowRoot?.elementFromPoint(x, y) ?? topLevelTarget;
-
+async function clickMapAt({ x, y }: { x: number; y: number }): Promise<void> {
+  const target = document.elementFromPoint(x, y);
   assert(target);
-
-  const options = { clientX: point.x, clientY: point.y };
-  fireEvent.pointerDown(target, options);
-  fireEvent.pointerUp(target, options);
+  await page.elementLocator(target).click({
+    position: {
+      x: x - target.getBoundingClientRect().left,
+      y: y - target.getBoundingClientRect().top,
+    },
+  });
 }

--- a/2026/build-tooling/demo/9-plugins/package.json
+++ b/2026/build-tooling/demo/9-plugins/package.json
@@ -14,10 +14,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^5.0.2",
-    "@arcgis/map-components": "^5.0.2",
+    "@arcgis/core": "^5.0.9",
+    "@arcgis/map-components": "^5.0.9",
     "@esri/calcite-components": "^5.0.2",
-    "@esri/arcgis-rest-places": "^4.9.0",
+    "@esri/arcgis-rest-places": "^4.10.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.1"
@@ -34,7 +34,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
-    "globals": "^17.3.0",
+    "globals": "^17.4.0",
     "msw": "^2.12.10",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",

--- a/2026/build-tooling/demo/9-plugins/src/interfaces.ts
+++ b/2026/build-tooling/demo/9-plugins/src/interfaces.ts
@@ -7,6 +7,6 @@ export interface Result<T> {
 }
 
 export interface ServiceInfo {
-  authentication: ApiKeyManager;
+  authentication?: ApiKeyManager;
   endpoint?: string;
 }

--- a/2026/build-tooling/demo/9-plugins/src/main.tsx
+++ b/2026/build-tooling/demo/9-plugins/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";
@@ -8,7 +9,14 @@ const App = React.lazy(async () => await import("./App"));
 const Splash = React.lazy(async () => await import("./Splash"));
 
 const placesServiceInfo = {
-  authentication: ApiKeyManager.fromKey(import.meta.env.VITE_API_KEY),
+  authentication: (() => {
+    try {
+      return ApiKeyManager.fromKey(import.meta.env.VITE_API_KEY);
+    } catch (error) {
+      console.warn("No API key provided, places service will not work", error);
+      return undefined;
+    }
+  })(),
   // Use a local proxy in development mode
   endpoint: import.meta.env.DEV
     ? "/arcgis/rest/services/places-service/v1/places/near-point"

--- a/2026/build-tooling/demo/9-plugins/src/main.tsx
+++ b/2026/build-tooling/demo/9-plugins/src/main.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react-refresh/only-export-components */
+import esriConfig from "@arcgis/core/config.js";
+import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router";
-import { ApiKeyManager } from "@esri/arcgis-rest-request";
+import { BrowserRouter, Route, Routes } from "react-router";
 import "./index.css";
 
 const App = React.lazy(async () => await import("./App"));
@@ -22,6 +23,16 @@ const placesServiceInfo = {
     ? "/arcgis/rest/services/places-service/v1/places/near-point"
     : undefined,
 };
+
+// Proxy ArcGIS REST API requests via the development server so we can intercept them with our chaos monkey plugin
+if (import.meta.env.DEV) {
+  esriConfig.request.interceptors.push({
+    urls: /^https:\/\/services\.arcgis\.com\/V6ZHFr6zdgNZuVG0\/arcgis\/rest\/services\/NY%20Educational%20Attainment\/FeatureServer\/0\/query/i,
+    before(params) {
+      params.url = "/arcgis";
+    },
+  });
+}
 
 const root = document.getElementById("root");
 if (!root) {

--- a/2026/build-tooling/demo/9-plugins/src/tests/App.test.tsx
+++ b/2026/build-tooling/demo/9-plugins/src/tests/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, fireEvent } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { setupWorker } from "msw/browser";
 import { http, HttpResponse, passthrough } from "msw";
@@ -26,6 +26,7 @@ const worker = setupWorker(
 
 const it = itBase.extend({
   worker: [
+    // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       // Start the worker before the test.
       await worker.start({ quiet: true });
@@ -69,7 +70,7 @@ it("renders", () => {
 it("shows a popup details when a feature is clicked", async () => {
   const { container } = results;
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -83,7 +84,7 @@ it("shows a popup details when a feature is clicked", async () => {
 it("loads nearby schools for the selected feature", async () => {
   const { container } = results;
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -105,7 +106,7 @@ it("shows an error when loading schools fails", async () => {
     ),
   );
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -118,15 +119,13 @@ it("shows an error when loading schools fails", async () => {
     .not.toBeNull();
 });
 
-function clickMapAt(point: { x: number; y: number }) {
-  const { x, y } = point;
-  const topLevelTarget = document.elementFromPoint(x, y);
-  const target =
-    topLevelTarget?.shadowRoot?.elementFromPoint(x, y) ?? topLevelTarget;
-
+async function clickMapAt({ x, y }: { x: number; y: number }): Promise<void> {
+  const target = document.elementFromPoint(x, y);
   assert(target);
-
-  const options = { clientX: point.x, clientY: point.y };
-  fireEvent.pointerDown(target, options);
-  fireEvent.pointerUp(target, options);
+  await page.elementLocator(target).click({
+    position: {
+      x: x - target.getBoundingClientRect().left,
+      y: y - target.getBoundingClientRect().top,
+    },
+  });
 }

--- a/2026/build-tooling/demo/9-plugins/vite.config.ts
+++ b/2026/build-tooling/demo/9-plugins/vite.config.ts
@@ -10,8 +10,13 @@ export default defineConfig({
     open: true,
     proxy: {
       "/arcgis": {
-        target: "https://places-api.arcgis.com",
+        target: "https://services.arcgis.com",
         changeOrigin: true,
+        rewrite: (path) =>
+          path.replace(
+            /^\/arcgis(?=\?|$)/u,
+            "/V6ZHFr6zdgNZuVG0/arcgis/rest/services/NY%20Educational%20Attainment/FeatureServer/0/query",
+          ),
       },
     },
   },
@@ -21,9 +26,7 @@ export default defineConfig({
       ? chaosMonkey([
           {
             apiUrl: "/arcgis",
-            delay: 400,
             chaosRatio: 0.5,
-            // https://developers.arcgis.com/rest/places/near-point-get/#response
             chaosErrors: [400, 401, 403, 500],
           },
         ])

--- a/2026/build-tooling/demo/final/package.json
+++ b/2026/build-tooling/demo/final/package.json
@@ -14,10 +14,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^5.0.2",
-    "@arcgis/map-components": "^5.0.2",
+    "@arcgis/core": "^5.0.9",
+    "@arcgis/map-components": "^5.0.9",
     "@esri/calcite-components": "^5.0.2",
-    "@esri/arcgis-rest-places": "^4.9.0",
+    "@esri/arcgis-rest-places": "^4.10.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.1"
@@ -33,14 +33,14 @@
     "@vitest/browser-playwright": "^4.0.18",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.5.0",
-    "globals": "^17.3.0",
+    "eslint-plugin-react-refresh": "^0.5.2",
+    "globals": "^17.4.0",
     "msw": "^2.12.10",
     "playwright": "^1.58.2",
     "prettier": "^3.8.1",
     "sonda": "^0.11.1",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.56.0",
+    "typescript-eslint": "^8.56.1",
     "vite": "^7.3.1",
     "vitest": "^4.0.18"
   }

--- a/2026/build-tooling/demo/final/src/interfaces.ts
+++ b/2026/build-tooling/demo/final/src/interfaces.ts
@@ -7,6 +7,6 @@ export interface Result<T> {
 }
 
 export interface ServiceInfo {
-  authentication: ApiKeyManager;
+  authentication?: ApiKeyManager;
   endpoint?: string;
 }

--- a/2026/build-tooling/demo/final/src/main.tsx
+++ b/2026/build-tooling/demo/final/src/main.tsx
@@ -9,7 +9,14 @@ const App = React.lazy(async () => await import("./App"));
 const Splash = React.lazy(async () => await import("./Splash"));
 
 const placesServiceInfo = {
-  authentication: ApiKeyManager.fromKey(import.meta.env.VITE_API_KEY),
+  authentication: (() => {
+    try {
+      return ApiKeyManager.fromKey(import.meta.env.VITE_API_KEY);
+    } catch (error) {
+      console.warn("No API key provided, places service will not work", error);
+      return undefined;
+    }
+  })(),
   // Use a local proxy in development mode
   endpoint: import.meta.env.DEV
     ? "/arcgis/rest/services/places-service/v1/places/near-point"

--- a/2026/build-tooling/demo/final/src/main.tsx
+++ b/2026/build-tooling/demo/final/src/main.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route } from "react-router";

--- a/2026/build-tooling/demo/final/src/tests/App.test.tsx
+++ b/2026/build-tooling/demo/final/src/tests/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, fireEvent } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { ApiKeyManager } from "@esri/arcgis-rest-request";
 import { setupWorker } from "msw/browser";
 import { http, HttpResponse, passthrough } from "msw";
@@ -26,6 +26,7 @@ const worker = setupWorker(
 
 const it = itBase.extend({
   worker: [
+    // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       // Start the worker before the test.
       await worker.start({ quiet: true });
@@ -69,7 +70,7 @@ it("renders", () => {
 it("shows a popup details when a feature is clicked", async () => {
   const { container } = results;
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -83,7 +84,7 @@ it("shows a popup details when a feature is clicked", async () => {
 it("loads nearby schools for the selected feature", async () => {
   const { container } = results;
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -105,7 +106,7 @@ it("shows an error when loading schools fails", async () => {
     ),
   );
 
-  clickMapAt({ x: 500, y: 100 });
+  await clickMapAt({ x: 500, y: 100 });
 
   await expect
     .poll(() => container.querySelector("arcgis-features")?.features)
@@ -118,15 +119,13 @@ it("shows an error when loading schools fails", async () => {
     .not.toBeNull();
 });
 
-function clickMapAt(point: { x: number; y: number }) {
-  const { x, y } = point;
-  const topLevelTarget = document.elementFromPoint(x, y);
-  const target =
-    topLevelTarget?.shadowRoot?.elementFromPoint(x, y) ?? topLevelTarget;
-
+async function clickMapAt({ x, y }: { x: number; y: number }): Promise<void> {
+  const target = document.elementFromPoint(x, y);
   assert(target);
-
-  const options = { clientX: point.x, clientY: point.y };
-  fireEvent.pointerDown(target, options);
-  fireEvent.pointerUp(target, options);
+  await page.elementLocator(target).click({
+    position: {
+      x: x - target.getBoundingClientRect().left,
+      y: y - target.getBoundingClientRect().top,
+    },
+  });
 }

--- a/2026/build-tooling/slides.md
+++ b/2026/build-tooling/slides.md
@@ -235,26 +235,47 @@ layout: intro
 
 # Enhance the app
 
+<!--
+Now let’s look at how we can make apps faster and easier to maintain.
+
+We’ll look at:
+- Lazy loading and routes
+- Bundle analysis
+- Testing
+- Vite plugins
+-->
+
 ---
 
-# ArcGIS Maps SDK for JavaScript
-
-- Powerful GIS mapping library
-- Now simpler to use thanks to web components
-
----
-
-# Lazy loading
+# Routes and Lazy loading
 
 - Only load source files when needed
 - Split app into multiple entry points
 - Simplest split: by page or route
+
+<!--
+Most apps have multiple pages, and a lot of code.
+
+Instead of loading everything up front, we only load what the user needs for the page they’re on.
+
+Routes give us a really natural split:
+start small on a splash page, and load the “real app” only when the user goes there.
+-->
 
 ---
 layout: center
 ---
 
 # Demo: [Lazy loading & routes with React Router](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/6-routes)
+
+<!--
+We’ll start on the splash page first.
+
+Now when we go to the map route, that’s when the heavier code loads.
+
+The nice part is this is just standard React patterns: lazy + dynamic import.
+Vite turns that into a separate bundle automatically.
+-->
 
 ---
 
@@ -265,11 +286,25 @@ layout: center
 - Find large or duplicated dependencies before they impact users
 - Works with Vite, Rollup, Rolldown, Webpack, esbuild, etc
 
+<!--
+Sometimes bundles can get big, even with lazy loading. Sonda is a great tool to understand why.
+-->
+
 ---
 layout: center
 ---
 
 # Demo: [Analyze bundles with Sonda](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/7-sonda)
+
+<!--
+All I need is to add the Sonda plugin to my Vite config.
+After doing a production build, I can view the report in the browser.
+
+First, look at the treemap: big boxes are big parts of your bundle.
+
+Then we can click around and see what pulls those chunks in.
+That makes it much easier to decide what to optimize.
+-->
 
 ---
 
@@ -283,11 +318,33 @@ tests:
 - Run tests in Node or the browser
 - Direct integration with Vite
 
+<!--
+As it says on the slide, if you’re not writing tests, you should be.
+
+These days, using tools like Vitest makes it really easy to get started.
+
+For UI + maps, browser-mode tests are a great fit and Vitest has built-in support for that.
+- real clicks and pointer events
+- stable, mocked APIs
+
+And it all integrates directly with Vite so you can use the same config and plugins for your tests as you do for your app.
+-->
+
 ---
 layout: center
 ---
 
 # Demo: [Add tests with Vitest](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/8-testing)
+
+<!--
+Let's look at a couple of tests that cover real user behavior.
+
+We render the app, click on the map, and confirm the UI updates.
+
+We can also simulate an API failure and confirm we show an error.
+
+The key ideas: fast, repeatable, and close to how users interact.
+-->
 
 ---
 
@@ -296,11 +353,29 @@ layout: center
 - Vite plugins are flexible and easy to write
 - Powerful way to enhance builds or developer workflows
 
+<!--
+Sometimes you need to do something that's not built into Vite.
+
+It comes with a rich plugin API that lets you hook into the build process and dev server.
+
+Common use-cases:
+- Dev server helpers (middleware)
+- Build-time tooling (analysis, transforms), like Sonda which we saw earlier
+-->
+
 ---
 layout: center
 ---
 
 # Demo: [Add custom plugins](https://github.com/maxpatiiuk/esri-dev-summit-presentations/tree/main/2026/build-tooling/demo/9-plugins)
+
+<!--
+To exemplify this, we built custom plugin that makes the dev server “unreliable” on purpose.
+
+If we run the app with "chaos mode" enabled, the plugin will randomly delay responses and fail some requests.
+
+This is a great way to test loading states and error handling without touching app logic.
+-->
 
 ---
 
@@ -310,6 +385,16 @@ layout: center
 - **Sonda 📦** helps visualize and optimize bundle size
 - **Testing with Vitest 🧪** makes it easy to write and maintain tests
 - **Custom plugins 🔌** provides a powerful way to enhance workflows
+
+<!--
+Big idea: you don’t need a new stack to scale an app.
+
+Just add a few simple practices:
+- Split by route
+- Measure and optimize bundle size with tools like Sonda
+- Add good tests (AI agents make this easier than ever!)
+- Use plugins when you need custom behavior
+-->
 
 ---
 


### PR DESCRIPTION
- Add speaker notes
- Demos:
   - Update dependencies
   - Improve tests to use Vitest browser mode clicks instead of testing library `fireEvent` calls.
   - Fix runtime issue caused by `ApiKeyManager` - we can stick to the local demo for now.
   - Instead of intercepting places API calls with the chaos monkey, intercept feature service API calls.