### PR TITLE
perf(2026): reduce image redirects

### DIFF
--- a/2026/.meta/footer.md
+++ b/2026/.meta/footer.md
@@ -13,49 +13,49 @@ Join the Conversation using #EsriDevTech2026
 <ul class="flex flex-col !list-none gap-3">
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/x.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/x.png"
       class="h-7"
     />
     <a href="https://x.com/EsriDevs" target="_new">x.com/EsriDevs</a>
   </li>
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/x.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/x.png"
       class="h-7"
     />
     <a href="https://x.com/EsriDevEvents" target="_new">x.com/EsriDevEvents</a>
   </li>
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/youtube.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/youtube.png"
       class="h-7"
     />
     <a href="http://www.youtube.com/@EsriDevs" target="_new">youtube.com/@EsriDevs</a>
   </li>
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/video.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/video.png"
       class="h-7"
     />
     <a href="https://links.esri.com/DevVideos" target="_new">links.esri.com/DevVideos</a>
   </li>
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/github.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/github.png"
       class="h-7"
     />
     <a href="https://github.com/Esri" target="_new">github.com/Esri</a>
   </li>
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/github.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/github.png"
       class="h-7"
     />
     <a href="https://github.com/EsriDevEvents" target="_new">github.com/EsriDevEvents</a>
   </li>
   <li class="flex items-center gap-4">
     <img
-      src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/community.png?raw=true"
+      src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/community.png"
       class="h-7"
     />
     <a href="https://links.esri.com/EsriDevCommunity" target="_new">links.esri.com/EsriDevCommunity</a>

--- a/2026/.meta/slide-bottom.vue
+++ b/2026/.meta/slide-bottom.vue
@@ -1,31 +1,31 @@
 <template>
   <img
     alt=""
-    src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/02.jpg?raw=true"
+    src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/02.jpg"
   />
   <img
     alt=""
-    src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/01.jpg?raw=true"
+    src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/01.jpg"
     v-show="$nav.currentPage === 1"
   />
   <img
     alt=""
-    src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/03.jpg?raw=true"
+    src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/03.jpg"
     v-show="$frontmatter.layout === 'intro'"
   />
   <img
     alt='Please share your feedback in the app: 1. Select "My Event" in the event app main menu. 2. Select "My Surveys". 3. Select the desired survey. 4. Complete the survey'
-    src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/05.jpg?raw=true"
+    src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/05.jpg"
     v-show="$frontmatter.is === 'feedback'"
   />
   <img
     alt=""
-    src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/03.jpg?raw=true"
+    src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/03.jpg"
     v-show="$frontmatter.is === 'social'"
   />
   <img
     alt="Esri logo"
-    src="https://github.com/Esri/reveal.js/blob/dev-summit-2026/images/2026/dev/07.jpg?raw=true"
+    src="https://raw.githubusercontent.com/Esri/reveal.js/refs/tags/dev-summit-2026/images/2026/dev/07.jpg"
     v-show="$frontmatter.is === 'esri'"
   />
 </template>

--- a/2026/build-tooling/slides.md
+++ b/2026/build-tooling/slides.md
@@ -46,8 +46,8 @@ that is most performant for the browser to run.
 graph LR
   subgraph human_files["Human-readable files"]
     direction LR
-    JS[JavaScript .js/.jsx]
-    TS[TypeScript .ts/.tsx]
+    JS[JavaScript .js/.ts]
+    NPM[NPM dependencies]
     CSS[CSS/Sass .css/.scss]
     IMG[Assets .jpg/.json]
   end

--- a/2026/build-tooling/slides.md
+++ b/2026/build-tooling/slides.md
@@ -47,9 +47,9 @@ graph LR
   subgraph human_files["Human-readable files"]
     direction LR
     JS[JavaScript .js/.ts]
-    NPM[NPM dependencies]
     CSS[CSS/Sass .css/.scss]
     IMG[Assets .jpg/.json]
+    NPM[NPM dependencies]
   end
 
   Bundler("Bundler")

--- a/2026/using-components-2/slides.md
+++ b/2026/using-components-2/slides.md
@@ -146,8 +146,8 @@ that is most performant for the browser to run.
 graph LR
   subgraph human_files["Human-readable files"]
     direction LR
-    JS[JavaScript .js/.jsx]
-    TS[TypeScript .ts/.tsx]
+    JS[JavaScript .js/.ts]
+    NPM[NPM dependencies]
     CSS[CSS/Sass .css/.scss]
     IMG[Assets .jpg/.json]
   end

--- a/2026/using-components-2/slides.md
+++ b/2026/using-components-2/slides.md
@@ -147,9 +147,9 @@ graph LR
   subgraph human_files["Human-readable files"]
     direction LR
     JS[JavaScript .js/.ts]
-    NPM[NPM dependencies]
     CSS[CSS/Sass .css/.scss]
     IMG[Assets .jpg/.json]
+    NPM[NPM dependencies]
   end
 
   Bundler("Bundler")


### PR DESCRIPTION
1. Use the direct urls to images rather than the redirect urls. This halfs the number of network requests and hopefully would reduce the 429 errors.
2. Updated the bundler diagram to mention NPM dependencies (third-party code). I think it helps distinguish bundlers from CDN as bundlers make consuming third-party code simpler.